### PR TITLE
Adds error checking to Kafka deployments

### DIFF
--- a/provision-kafka.yml
+++ b/provision-kafka.yml
@@ -17,22 +17,45 @@
     # if we're using dynamic provisioning; build the host groups from the
     # meta-data associated with the matching nodes in the selected cloud
     - block:
-      # if we're deploying instances in an cloud environment, ensure that there
-      # are an appriately tagged set of nodes already (and launch them if they
-      # don't exist based on the node_map entries for this application)
-      - include_role:
-          name: 'aws'
-        when: cloud is undefined or cloud == 'aws'
-      - include_role:
-          name: 'osp'
-        when: cloud == 'osp'
-      # then, build the zookeeper group from those nodes
+      # get a list of the node_map entries for this application
+      - set_fact:
+          node_map_entries: "{{node_map | selectattr('application', 'equalto', application) | list}}"
+      # if more than one node_map entry was found or no matching node_map
+      # entries were found, then it's an error
+      - fail:
+          msg: "Multiple {{application}} node_map entries found"
+        when: node_map_entries | length > 1
+      - fail:
+          msg: "No {{application}} node_map entries found"
+        when: node_map_entries | length == 0
+      # build the kafka and zookeeper host groups from existing inventory
       - include_role:
           name: build-app-host-groups
         vars:
           host_group_list:
             - name: kafka
             - name: zookeeper
+      - set_fact:
+          num_kafka_nodes: "{{groups['kafka'] | default([]) | length}}"
+          num_zk_nodes: "{{groups['zookeeper'] | default([]) | length}}"
+      # if an external Zookeeper ensemble (or node) was not found and we're
+      # deploying an Kafka cluster (or multiple matching Kafka nodes were
+      # found), then it's an error
+      - fail:
+          msg: "An external Zookeeper ensemble is required for Kafka cluster deployments"
+        when:
+          - (num_kafka_nodes | int == 0 and node_map_entries.0.count > 1) or num_kafka_nodes | int > 1
+          - num_zk_nodes | int == 0
+      # if there were no Kafka nodes found, then deploy a matching set of
+      # instances into the target cloud environment, ensuring that there
+      # are an appropriately tagged, based on the input tags and the node_map
+      # entries for this application
+      - include_role:
+          name: 'aws'
+        when: num_kafka_nodes | int == 0 and cloud == 'aws'
+      - include_role:
+          name: 'osp'
+        when: num_kafka_nodes == 0 and cloud == 'osp'
       when: cloud is defined and (cloud == 'aws' or cloud == 'osp')
 
 # If we're dynamically provisioning, then do some final configuration on the
@@ -62,7 +85,7 @@
           configured_nodes: true
       when:
         - cloud is defined and (cloud == 'aws' or cloud == 'osp')
-        - ((force_node_reconfig | default(false)) | bool) or not(hostvars['localhost']['matching_instances_found'])
+        - ((force_node_reconfig | default(false)) | bool) or ((hostvars['localhost']['num_kafka_nodes'] | int) == 0)
 
 # Collect some Zookeeper related facts
 - name: Gather facts from Zookeeper host group (if defined)

--- a/roles/aws/tasks/launch-amis.yml
+++ b/roles/aws/tasks/launch-amis.yml
@@ -131,7 +131,7 @@
   stat: path="{{keyfile_path}}"
   register: existing_key
 # if there is an existing key, use it
-- block: 
+- block:
   - name: Generate public key from existing {{region}}-{{project}}-{{application}}-{{domain}}-private-key.pem
     command: "/usr/bin/ssh-keygen -f {{keyfile_path}} -y"
     register: public_key_from_pem
@@ -140,7 +140,7 @@
       region: "{{region}}"
       state: present
       name: "{{region}}-{{project}}-{{application}}-{{domain}}"
-      key_material: "{{public_key_from_pem.stdout}}" 
+      key_material: "{{public_key_from_pem.stdout}}"
     register: old_keypair
   - set_fact: keypair="{{old_keypair}}"
   when: existing_key.stat.exists
@@ -162,7 +162,7 @@
 - name: Launch AMIs
   ec2:
     key_name: "{{keypair.key.name}}"
-    group_id: 
+    group_id:
       - "{{sg_ssh.group_id}}"
       - "{{sg_application_internal.group_id}}"
     instance_type: "{{type | default('t2.micro')}}"
@@ -283,6 +283,22 @@
       loop_var: instance
     when: not (ec2 | skipped) and (ec2_instances | length) > 0
   when: not(multi_interface)
+# construct the `app_group_name_list` and `node_list_name_list` lists from the
+# `application_roles` list
+- set_fact:
+    node_list_name_list: "{{(node_list_name_list | default([])) + [((instance.tags.Role == 'none') | ternary((application + '_nodes'), (application + '_' + instance.tags.Role + '_nodes')))]}}"
+    app_group_name_list: "{{(app_group_name_list | default([])) + [((instance.tags.Role == 'none') | ternary(application, application + '_' + instance.tags.Role))]}}"
+  with_items: "{{ec2_instances}}"
+  loop_control:
+    loop_var: instance
+# add the instances created to the corresponding application host groups
+- name: Add new instances to the appropriate host groups
+  add_host:
+    hostname: "{{item.1.private_ip}}"
+    groups: "{{app_group_name_list[item.0 | int]}},{{node_list_name_list[item.0 | int]}}"
+    ansible_ssh_private_key_file: "{{keyfile_path}}"
+  with_indexed_items: "{{ec2_instances}}"
+  when: not (ec2 | skipped) and (ec2_instances | length) > 0
 # wait_for doesn't work with a proxy, so we need to ssh and check output
 - name: Wait for instances to be accessible via SSH
   shell: /bin/sleep 10 && /usr/bin/ssh -i "{{keyfile_path}}" "{{user}}"@"{{instance.private_ip}}" echo DataNexus

--- a/roles/aws/tasks/main.yml
+++ b/roles/aws/tasks/main.yml
@@ -1,6 +1,13 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved.
 ---
-# first, determine the list of roles used in a deployment for this application;
+# first, check to make sure that the external_subnet is defined; if it is not,
+# then it's an error
+- name: Ensure that external_subnet is defined
+  fail:
+    msg: "The external_subnet parameter must be defined"
+  run_once: true
+  when: external_subnet is undefined
+# next, determine the list of roles used in a deployment for this application;
 # start by selecting the node map entries for this application
 - set_fact:
     node_map_entries: "{{node_map | selectattr('application', 'equalto', application) | list}}"
@@ -36,11 +43,11 @@
 - set_fact:
     matching_instances_found: "{{not (matching_instances | length) == 0}}"
     root_volume_default: "{{(data_volume is defined) | ternary(11, 40)}}"
-    multi_interface: "{{external_subnet is defined and external_subnet != internal_subnet}}"
+    multi_interface: "{{internal_subnet is defined and external_subnet != internal_subnet}}"
 - set_fact:
-    external_subnet: "{{internal_subnet}}"
-  when: external_subnet is undefined
+    internal_subnet: "{{external_subnet}}"
+  when: internal_subnet is undefined
 # if we didn't find any matching instances that are running, then
 # launch a set of VMs with those tags
-- include: launch-amis.yml static=no        
+- include: launch-amis.yml static=no
   when: not matching_instances_found

--- a/roles/build-app-host-groups/tasks/main.yml
+++ b/roles/build-app-host-groups/tasks/main.yml
@@ -1,24 +1,18 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
-# If we're running this command for to build a cluster in OpenStack, and if we
-# haven't gathered inventory data yet in this play or if the inventory info
-# that we gathered earlier (in the `osp` role) is out of date because there
-# were no new nodes added to the environment and, as such, we added new nodes
-# to the environment, then use the`openstack.py` command to gather the dynamic
-# inventory information that we need to build our application host groups
+# If we're building a cluster in an OpenStack environment, then use the
+# `openstack.py` command to gather the dynamic inventory information that we
+# need to build our application host groups
 - block:
+  # first run the `openstack.py` command to gather the inventory information
   - name: Run openstack command to gather inventory information
     shell: "{{role_path}}/utils/openstack.py --list"
     register: os_inventory_output
     run_once: true
   - set_fact:
       os_inventory_json: "{{os_inventory_output.stdout | from_json}}"
-  when:
-    - cloud == "osp"
-    - matching_instances_found is undefined or (not matching_instances_found)
-# then build lists of matching nodes based on the defined cloud, tenant, project
-# dataflow, domain, and cluster
-- block:
+  # then build lists of matching nodes based on the defined cloud, tenant, project
+  # dataflow, domain, and cluster
   - set_fact:
       cloud_nodes: "{{(os_inventory_json | json_query('[\"meta-Cloud_' + cloud + '\"]')).0}}"
       tenant_nodes: "{{(os_inventory_json | json_query('[\"meta-Tenant_' + tenant + '\"]')).0}}"
@@ -26,15 +20,15 @@
       dataflow_nodes: "{{(os_inventory_json | json_query('[\"meta-Dataflow_' + (dataflow | default('none')) + '\"]')).0}}"
       domain_nodes: "{{(os_inventory_json | json_query('[\"meta-Domain_' + domain + '\"]')).0}}"
       cluster_nodes: "{{(os_inventory_json | json_query('[\"meta-Cluster_' + (cluster | default('a')) + '\"]')).0}}"
-  # then loop through the host_group_list, building each host group (in turn)
+  # and, finally, loop through the host_group_list, building each host group
+  # (in turn) from the lists of nodes we just constructed
   - include: ../files/build_osp_host_groups.yml
     with_items: "{{host_group_list}}"
     loop_control:
       loop_var: host_group_item
   when: cloud == "osp"
-
-# If we're running this command for to build a cluster in OpenStack, then loop
-# through the host_group_list, building each host group (in turn)
+# If we're building a cluster in an AWS environtment, then loop through the
+# host_group_list, building each host group (in turn)
 - include: ../files/build_aws_host_groups.yml
   with_items: "{{host_group_list}}"
   loop_control:

--- a/roles/initialize-play/tasks/main.yml
+++ b/roles/initialize-play/tasks/main.yml
@@ -7,10 +7,17 @@
   include_vars:
     file: "{{config_file | default('config.yml')}}"
 # now that we've loaded the configuration file, ensure that a value is set
-# for the external_subnet parameter
-- set_fact:
-    external_subnet: "{{internal_subnet}}"
+# for the internal_subnet parameter by setting it to the same value as the
+# external_subnet if it is undefined; if the external_subnet parameter is
+# undefined, then it's an error
+- name: Ensure that external_subnet is defined
+  fail:
+    msg: "The external_subnet parameter must be defined"
+  run_once: true
   when: external_subnet is undefined
+- set_fact:
+    internal_subnet: "{{external_subnet}}"
+  when: internal_subnet is undefined
 # and define an interface description array based on the the internal and
 # external subnets that have been defined and the variable names that are
 # used during the playbook run (the `data_iface` and `api_iface` variables)

--- a/roles/osp/tasks/launch-vms.yml
+++ b/roles/osp/tasks/launch-vms.yml
@@ -98,13 +98,13 @@
   stat: path="{{public_keyfile_path}}"
   register: existing_key
 # if there is an existing key, use it
-- block: 
+- block:
   - name: Use existing public key at {{public_keyfile_path}}
     os_keypair:
       cloud: "{{tenant}}"
       state: present
       name: "{{region}}-{{project}}-{{application}}-{{domain}}"
-      public_key_file: "{{public_keyfile_path}}" 
+      public_key_file: "{{public_keyfile_path}}"
     register: old_keypair
   - set_fact: keypair="{{old_keypair}}"
   when: existing_key.stat.exists
@@ -164,7 +164,7 @@
       Application: "{{application}}"
       Cluster: "{{cluster | default('a')}}"
       Role: "{{node_role_list[item | int]}}"
-      Dataflow: "{{dataflow | default('none')}}"    
+      Dataflow: "{{dataflow | default('none')}}"
     region_name: "{{region}}"
     availability_zone: "{{zone}}"
     image: "{{image}}"
@@ -189,8 +189,22 @@
     network: "{{float_pool}}"
     nat_destination: "{{external_uuid}}"
   with_items: "{{osp_out.results}}"
-  register: 
+  register:
   when: not osp_out | skipped and osp_out.changed and osp_out.results | length > 0
+# construct the `app_group_name_list` and `node_list_name_list` lists from the
+# `application_roles` list
+- set_fact:
+    node_list_name_list: "{{(node_list_name_list | default([])) + [((item == 'none') | ternary((application + '_nodes'), (application + '_' + item + '_nodes')))]}}"
+    app_group_name_list: "{{(app_group_name_list | default([])) + [((item == 'none') | ternary(application, application + '_' + item))]}}"
+  with_items: "{{node_role_list}}"
+# add the instances created to the corresponding application host group
+- name: Add new instances to the appropriate host groups
+  add_host:
+    name: "{{item.1.server.addresses.private.0['addr']}}"
+    groups: "{{app_group_name_list[item.0 | int]}},{{node_list_name_list[item.0 | int]}}"
+    ansible_ssh_host: "{{item.1.server.addresses.private.0['addr']}}"
+    ansible_ssh_private_key_file: "{{private_keyfile_path}}"
+  with_indexed_items: "{{osp_out.results}}"
 # wait_for doesn't work with a proxy, so we need to ssh and check output
 - name: Wait for instances to be accessible via SSH
   shell: /bin/sleep 10 && /usr/bin/ssh -i "{{private_keyfile_path}}" "{{user}}@{{item.server.addresses.private.0['addr']}}" echo DataNexus

--- a/roles/osp/tasks/main.yml
+++ b/roles/osp/tasks/main.yml
@@ -1,7 +1,13 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved.
 ---
-# Launch VMs if they aren't already running; to do so, we first need to
-# determine the list of roles used in a deployment for this application;
+# first, check to make sure that the external_subnet is defined; if it is not,
+# then it's an error
+- name: Ensure that external_subnet is defined
+  fail:
+    msg: "The external_subnet parameter must be defined"
+  run_once: true
+  when: external_subnet is undefined
+# next, determine the list of roles used in a deployment for this application;
 # start by selecting the node map entries for this application
 - set_fact:
     node_map_entries: "{{node_map | selectattr('application', 'equalto', application) | list}}"
@@ -13,25 +19,6 @@
 # should be added to the `roles_list` we just constructed, above)
 - set_fact:
     application_roles: "{{((roles_list | length) == (node_map_entries | length)) | ternary(roles_list, roles_list + ['none'])}}"
-# If we're running this command for to build a cluster in OpenStack, then use
-# the`openstack.py` command to gather the dynamic inventory information that
-# we need to build our application host groups
-- name: Run openstack command to gather inventory information
-  shell: "{{role_path}}/utils/openstack.py --list"
-  register: os_inventory_output
-  run_once: true
-- set_fact:
-    os_inventory_json: "{{os_inventory_output.stdout | from_json}}"
-# then build lists of matching nodes based on the defined cloud, tenant, project
-# dataflow, domain, and cluster
-- set_fact:
-    cloud_nodes: "{{(os_inventory_json | json_query('[\"meta-Cloud_' + cloud + '\"]')).0}}"
-    tenant_nodes: "{{(os_inventory_json | json_query('[\"meta-Tenant_' + tenant + '\"]')).0}}"
-    project_nodes: "{{(os_inventory_json | json_query('[\"meta-Project_' + project + '\"]')).0}}"
-    dataflow_nodes: "{{(os_inventory_json | json_query('[\"meta-Dataflow_' + (dataflow | default('none')) + '\"]')).0}}"
-    domain_nodes: "{{(os_inventory_json | json_query('[\"meta-Domain_' + domain + '\"]')).0}}"
-    application_nodes: "{{(os_inventory_json | json_query('[\"meta-Application_' + application + '\"]')).0}}"
-    cluster_nodes: "{{(os_inventory_json | json_query('[\"meta-Cluster_' + (cluster | default('a')) + '\"]')).0}}"
 # and build a list of the instances that match the input roles from the
 # matching `node_map` entries
 - set_fact:
@@ -45,11 +32,11 @@
 - set_fact:
     matching_instances_found: "{{not (matching_instances | length) == 0}}"
     root_volume_default: "{{(data_volume is defined) | ternary(11, 40)}}"
-    multi_interface: "{{external_subnet is defined and external_subnet != internal_subnet}}"
+    multi_interface: "{{internal_subnet is defined and external_subnet != internal_subnet}}"
 - set_fact:
-    external_subnet: "{{internal_subnet}}"
-  when: external_subnet is undefined
+    internal_subnet: "{{external_subnet}}"
+  when: internal_subnet is undefined
 # if we didn't find any matching instances, then launch a set of VMs that are
 # tagged with the input tags
-- include: launch-vms.yml static=no        
+- include: launch-vms.yml static=no
   when: not matching_instances_found


### PR DESCRIPTION
The changes in this pull request add some error checking to the inputs to the `provision-kafka.yml` playbook; specifically:

* inverts the process of provisioning new VMs in AWS/OSP environments and building the host groups (this new code builds the host groups, then creates new nodes and adds them to those host groups if no existing nodes are found; previously the new nodes were provisioned and then the host groups were built)
* adds some error checking for the number of `kafka` entries found in the `node_map` list; if there is more than one found (or none are found) then an error is thrown
* adds a check to ensure that an external Zookeeper ensemble exists for use in Kafka cluster deployments; if the playbook is performing a cluster deployment and an external Zookeeper node or ensemble is not found then an error is thrown
* updates the `osp`, `aws`, and `build-app-host-groups` roles to support the inverted call order mentioned above

With these changes merged, the Kafka deployment process should be in line with the other community (open-sourced) application deployment playbooks that we are supporting.