### PR TITLE
Bring roles into line with roles used in solr repository

### DIFF
--- a/provision-kafka.yml
+++ b/provision-kafka.yml
@@ -22,10 +22,12 @@
           node_map_entries: "{{node_map | selectattr('application', 'equalto', application) | list}}"
       # if more than one node_map entry was found or no matching node_map
       # entries were found, then it's an error
-      - fail:
+      - name: Fail playbook run if multiple kafka node_map entries were found
+        fail:
           msg: "Multiple {{application}} node_map entries found"
         when: node_map_entries | length > 1
-      - fail:
+      - name: Fail playbook run if no kafka node_map entries were found
+        fail:
           msg: "No {{application}} node_map entries found"
         when: node_map_entries | length == 0
       # build the kafka and zookeeper host groups from existing inventory
@@ -49,7 +51,8 @@
       # if an external Zookeeper ensemble (or node) was not found and we're
       # deploying an Kafka cluster (or multiple matching Kafka nodes were
       # found), then it's an error
-      - fail:
+      - name: Fail playbook run if cluster deployment and external zookeeper ensemble not found
+        fail:
           msg: "An external Zookeeper ensemble is required for Kafka cluster deployments"
         when:
           - (num_kafka_nodes | int == 0 and node_map_entries.0.count > 1) or num_kafka_nodes | int > 1

--- a/provision-kafka.yml
+++ b/provision-kafka.yml
@@ -61,10 +61,12 @@
       # instances into the target cloud environment, ensuring that there
       # are an appropriately tagged, based on the input tags and the node_map
       # entries for this application
-      - include_role:
+      - name: Launch AWS VMs
+        include_role:
           name: 'aws'
         when: num_kafka_nodes | int == 0 and cloud == 'aws'
-      - include_role:
+      - name: Launch OSP VMs
+        include_role:
           name: 'osp'
         when: num_kafka_nodes | int == 0 and cloud == 'osp'
       when: cloud is defined and (cloud == 'aws' or cloud == 'osp')

--- a/roles/build-app-host-groups/files/build_osp_host_groups.yml
+++ b/roles/build-app-host-groups/files/build_osp_host_groups.yml
@@ -14,7 +14,7 @@
 - set_fact:
     application_nodes: "{{(os_inventory_json | json_query('[\"meta-Application_' + hg_item_name + '\"]')).0}}"
     role_nodes: "{{(os_inventory_json | json_query('[\"meta-Role_' + hg_item_role + '\"]')).0}}"
-  
+
 - set_fact:
     app_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(dataflow_nodes) | intersect(domain_nodes) | intersect(application_nodes) | intersect(cluster_nodes) | intersect(role_nodes)}}"
 
@@ -42,7 +42,7 @@
   when:
     - internal_uuid == external_uuid
 
-# multiple subnet hostgroups already have the correct ansible_host      
+# multiple subnet hostgroups already have the correct ansible_host
 - name: Create {{app_group_name}} host group from OpenStack meta-data
   add_host:
     name: "{{item}}"

--- a/roles/build-app-host-groups/files/build_osp_host_groups.yml
+++ b/roles/build-app-host-groups/files/build_osp_host_groups.yml
@@ -14,10 +14,8 @@
 - set_fact:
     application_nodes: "{{(os_inventory_json | json_query('[\"meta-Application_' + hg_item_name + '\"]')).0}}"
     role_nodes: "{{(os_inventory_json | json_query('[\"meta-Role_' + hg_item_role + '\"]')).0}}"
-
 - set_fact:
     app_nodes: "{{cloud_nodes | intersect(tenant_nodes) | intersect(project_nodes) | intersect(dataflow_nodes) | intersect(domain_nodes) | intersect(application_nodes) | intersect(cluster_nodes) | intersect(role_nodes)}}"
-
 # if a role was defined as part of this host group item, then run the
 # tasks this block
 - block:

--- a/roles/initialize-play/tasks/main.yml
+++ b/roles/initialize-play/tasks/main.yml
@@ -51,7 +51,6 @@
 # 'type' in each of those values; currently either 'cidr' or 'name' values
 # are supported for the 'type' field)
 - include_tasks: "{{role_path}}/files/get_iface_name.yml"
-  static: no
   with_items: "{{iface_description_array}}"
   loop_control:
     loop_var: iface_description
@@ -59,7 +58,6 @@
 # finally, get values for the addresses of the `data_iface` and `api_iface`
 # (if defined)
 - include_tasks: "{{role_path}}/files/get_iface_addr.yml"
-  static: no
   vars:
     iface_name: "{{data_iface}}"
     as_fact: "data_addr"
@@ -71,7 +69,6 @@
     api_iface: "{{(lcl_iface_names | reject('equalto', 'lo') | reject('equalto', data_iface) | list).0}}"
   when: api_iface == ''
 - include_tasks: "{{role_path}}/files/get_iface_addr.yml"
-  static: no
   vars:
     iface_name: "{{api_iface}}"
     as_fact: "api_addr"

--- a/roles/osp/tasks/launch-vms.yml
+++ b/roles/osp/tasks/launch-vms.yml
@@ -157,7 +157,7 @@
     node_list_name_list: "{{(node_list_name_list | default([])) + [((item == 'none') | ternary((application + '_nodes'), (application + '_' + item + '_nodes')))]}}"
     app_group_name_list: "{{(app_group_name_list | default([])) + [((item == 'none') | ternary(application, application + '_' + item))]}}"
   with_items: "{{node_role_list}}"
-    
+
 # this handles single subnet, eg, when internal and external uuids are identical
 # openstack instance names must be unique, so we need to add a sequence number to each name
 - block:
@@ -199,7 +199,7 @@
     with_indexed_items: "{{osp_single.results}}"
   when:
     - internal_uuid == external_uuid
-        
+
 # this handles multiple subnets
 # openstack instance names must be unique, so we need to add a sequence number to each name
 - block:
@@ -256,18 +256,17 @@
     with_indexed_items: "{{osp_multiple.results}}"
   when:
     - internal_uuid != external_uuid
-    
+
 # sigh @ ansible for making me do this
 - set_fact:
     osp: "{{ (internal_uuid == external_uuid) | ternary(osp_single, osp_multiple) }}"
-  
+
 # wait_for doesn't work with a proxy, so we need to ssh and check output
 - name: Wait for instances to be accessible via SSH
-  shell: /bin/sleep 20 && /usr/bin/ssh -i "{{ private_keyfile_path }}" "{{ user }}@{{ hostvars[item.server.addresses.private.0['addr']].ansible_host }}" echo DataNexus  
+  shell: /bin/sleep 20 && /usr/bin/ssh -i "{{ private_keyfile_path }}" "{{ user }}@{{ hostvars[item.server.addresses.private.0['addr']].ansible_host }}" echo DataNexus
   register: output
   retries: 4
   delay: 10
   until: output.stdout.find('DataNexus') != -1
   with_items: "{{osp.results}}"
   when: not osp | skipped and osp.changed and osp.results | length > 0
-

--- a/roles/osp/tasks/launch-vms.yml
+++ b/roles/osp/tasks/launch-vms.yml
@@ -128,14 +128,12 @@
       content: "{{keypair.key.public_key}}"
       mode: 0400
   when: not(existing_key.stat.exists)
-
 # from the matching `node_map` entries, build up a list of the role for each
 # node we'll be creating; first set  acouple of facts we'll need in the next
 # few tasks
 - set_fact:
     node_role_list: []
     nic_list: "{{ (internal_uuid != external_uuid) | ternary([{ 'net-id': internal_uuid }, { 'net-id': external_uuid }], [{ 'net-id': external_uuid }]) }}"
-
 - name: Build up a list of roles (per node being created)
   include_tasks: build-role-list.yml
   with_items: "{{node_map | selectattr('application', 'equalto', application) | list}}"
@@ -231,7 +229,6 @@
       volumes: "{{project}}_{{application}}_{{node_role_list[item | int]}}_{{cluster | default('a')}}_{{item}}"
     register: osp_multiple
     with_sequence: start=0 end="{{(node_role_list | length) - 1}}"
-
   # setup a floating IP address for each instance from the float_pool
   - name: assigning floating IPs to instances
     os_floating_ip:

--- a/roles/osp/tasks/main.yml
+++ b/roles/osp/tasks/main.yml
@@ -29,7 +29,6 @@
 - set_fact:
     role_nodes: "{{(role_nodes | default([])) + (os_inventory_json | json_query('[\"meta-Role_' + item + '\"]')).0}}"
   with_items: "{{application_roles}}"
-
 # now that we've built our lists of matching nodes, check to see if we have
 # any instances that match all of our input tags; we also set a few facts here
 # that are used when launching instances (below) if no matching nodes are found

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -11,7 +11,7 @@
       dest: "/etc/sysconfig/network-scripts/ifcfg-{{api_iface}}"
       remote_src: True
   - name: Replace the device in the new ifcfg-{{api_iface}} script
-    lineinfile: 
+    lineinfile:
       name: "/etc/sysconfig/network-scripts/ifcfg-{{api_iface}}"
       regexp: '^DEVICE='
       line: 'DEVICE="{{api_iface}}"'
@@ -81,7 +81,7 @@
   - name: Set hostname actively so rebooting is unnecessary
     command: /usr/bin/hostnamectl set-hostname {{application}}-{{uuid.stdout}}
   - name: Set pretty hostname actively so rebooting is unnecessary
-    command: /usr/bin/hostnamectl --pretty set-hostname "{{tenant}} {{application}}"  
+    command: /usr/bin/hostnamectl --pretty set-hostname "{{tenant}} {{application}}"
   - name: Set new hostname in /etc/hostname
     replace:
       path: /etc/hostname


### PR DESCRIPTION
The changes in this pull request bring the roles that are included in the `kafka` repository into line with the latest changes that were made to these roles in the `solr` repository. In addition, this pull request makes the following changes:

* It adds labels to the to the fail tasks in the `provision-kafka.yml` playbook in order to clarify the output of playbook run (some users were confused by the `fail ... skipped` output generated by previous versions of this file)
* It ensures that the labels added to the `include_role` tasks that include the `aws` and `osp` roles are consistent with these same labels in our other application playbooks (to make the output from our various playbooks more consistent; this change was made to some playbooks but not to others and the labels added were not consistent across the playbooks where they were added)

With these changes, the `kafka` repository should now be in line with recent changes that have been made to our other application repositories (`cassandra`, `solr`, etc.)