### PR TITLE
Removes limit on number of partitions when creating a new topic

### DIFF
--- a/tasks/add-kafka-topics.yml
+++ b/tasks/add-kafka-topics.yml
@@ -1,13 +1,13 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
 - name: Set the connection string used to communicate with Zookeeper
-  set_fact: 
+  set_fact:
     zk_node_str: "{{(zk_nodes | default(['localhost'])) | join(':2181,')}}:2181"
 - name: Create kafka topics
   run_once: true
   become: true
   become_user: "{{kafka_user}}"
-  shell: "{{kafka_topics_cmd}} --create --zookeeper {{zk_node_str}} --replication-factor {{[(item.repl_factor | default(1)), (kafka_nodes | length)] | min}} --partitions {{[(item.partitions | default(1)),(kafka_nodes | length)] | min}} --topic {{item.name}}"
+  shell: "{{kafka_topics_cmd}} --create --zookeeper {{zk_node_str}} --replication-factor {{[(item.repl_factor | default(1)), (kafka_nodes | length)] | min}} --partitions {{[(item.partitions | default(1)), 1] | max}} --topic {{item.name}}"
   with_items: "{{ kafka_topics_list | default([]) }}"
   register: command_result
   failed_when:


### PR DESCRIPTION
Previous versions of the provisioning playbook in this repository limited the number of partitions allowed when creating a new topic (using the `partitions` value in each of the topics listed in the `kafka_topics_list`) to the number of nodes in the cluster or less.

While this limitation **should** be applied for the `repl_factor` defined for each of the entries in that same list, the number of partitions should not be limited in this fashion (it should just be limited to being an integer number greater than zero). The changes in this pull request (a one-line change to the playbook code) ensure that this is the case.

The changes in this PR were tested with the following `kafka_topics_list` where a three-node Kafka cluster was being created in an AWS environment:

```yaml
kafka_topics_list:
  - { name: metrics, repl_factor: 2, partitions: 3 }
  - { name: logs, repl_factor: 2, partitions: 3 }
  - { name: test1, repl_factor: 2, partitions: -1 }
  - { name: test2, repl_factor: 2, partitions: 20 }
```

and for that test run, the resulting log directories on the three nodes looked something like this following:

```bash
$ ssh -i /Volumes/Extern-USB/Vagrant/kafka/us-west-2-demo-kafka-production-private-key.pem centos@10.10.1.73 'ls /data/kafka | grep test[12]* | sort -t'-' -k2 -n'
Warning: Permanently added '10.10.1.73' (ECDSA) to the list of known hosts.
test1-0
test2-1
test2-2
test2-3
test2-5
test2-7
test2-8
test2-9
test2-11
test2-13
test2-14
test2-15
test2-17
test2-19
Killed by signal 1.
$ ssh -i /Volumes/Extern-USB/Vagrant/kafka/us-west-2-demo-kafka-production-private-key.pem centos@10.10.1.116 'ls /data/kafka | grep test[12]* | sort -t'-' -k2 -n'
Warning: Permanently added '10.10.1.116' (ECDSA) to the list of known hosts.
test2-0
test2-1
test2-4
test2-5
test2-6
test2-7
test2-10
test2-11
test2-12
test2-13
test2-16
test2-17
test2-18
test2-19
Killed by signal 1.
$ ssh -i /Volumes/Extern-USB/Vagrant/kafka/us-west-2-demo-kafka-production-private-key.pem centos@10.10.1.44 'ls /data/kafka | grep test[12]* | sort -t'-' -k2 -n'
Warning: Permanently added '10.10.1.44' (ECDSA) to the list of known hosts.
test1-0
test2-0
test2-2
test2-3
test2-4
test2-6
test2-8
test2-9
test2-10
test2-12
test2-14
test2-15
test2-16
test2-18
Killed by signal 1.
$
```

If you look closely at that output, you'll see that there are exactly two copies of each of the `test[12]*` subdirectories (reflecting the replication factor of 2) and that there is one subdirectory for the `test1` topic and there are 20 subdirectories for the `test2` topic (distributed across all three nodes). The number of subdirectories for each topic results from the `partitions` parameter defined in the corresponding `kafka_topics_list` entry, with the following rules in mind

* for the `test1` topic, the defined partitions value (`-1`) is less than `1`, so a partitions value of `1` is used instead of the defined value (resulting in 1 subdirectory in the log directory of the machines maintaining the replicas for this topic)
* for the `test2` topic, the defined partitions value (`20`) is greater than `1`, so that partitions value is used (resulting in 20 subdirectories in the log directory for this topic, distributed across all three nodes in the cluster, with two copies of each subdirectory)

From this test, you can see that this fixes the previous version of the playbook in this repository (which would have limited the number of partitions in the second topic to `3` (the size of the Kafka cluster).