### PR TITLE
add support for apache kafka; eliminate variable duplication

### DIFF
--- a/build_aws_static_inventory.sh
+++ b/build_aws_static_inventory.sh
@@ -23,7 +23,7 @@ export TEE=/usr/bin/tee
 export CAT=/bin/cat
 
 # each application should be its own system
-applications="cruisecontrol shaw zookeeper kafka_broker controlcenter registry kafka_connect rest_proxy kafka_ksql kafka_replicator elasticsearch"
+applications="shaw zookeeper kafka_broker cruisecontrol controlcenter registry kafka_connect rest_proxy kafka_ksql kafka_replicator elasticsearch"
 # roles are application vms with dual purpose, eg controlcenter runs on a kafka node
 roles="replicator"
 

--- a/deploy
+++ b/deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # (c) Copyright 2016 DataNexus Inc.  All Rights Reserved. 
-# confluent platform deployment wrapper
+# kafka platform deployment wrapper
 
 : "${AWS_PROFILE:=datanexus}" && export AWS_PROFILE=${AWS_PROFILE}         # sets this to a reasonable ~/.aws/credentials default
 : "${AZURE_PROFILE:=datanexus}" && export AZURE_PROFILE=${AZURE_PROFILE}  # sets this to a reasonable ~/.azure/credentials default
@@ -17,8 +17,8 @@ application=confluent         # application overlay to deploy
 
 # if check is passed in as the last argument run the drift code
 for i in "$@" ; do 
-  [[ $i == "drift" ]] && ./provision-confluent --check --diff --inventory=$1 --tags "$application" -e "tenant_config_path=${2} project=$3 cloud=$4 region=$5 domain=$6 cluster=$7 tenant=${tenant} application=${application} key_path=${8}" | ./check && exit ;
+  [[ $i == "drift" ]] && ./provision-kafka --check --diff --inventory=$1 --tags "$application" -e "tenant_config_path=${2} project=$3 cloud=$4 region=$5 domain=$6 cluster=$7 tenant=${tenant} application=${application} key_path=${8}" | ./check && exit ;
   [[ $i == "replication" ]] && ./provision-replication --inventory=$1 --tags "$application" -e "tenant=$2 project=$3 cloud=$4 region=$5 domain=$6 cluster=$7" && exit ;
 done
 
-./provision-confluent --inventory=${1} --tags "${application}" -e "tenant_config_path=${2} project=$3 cloud=$4 region=$5 domain=$6 cluster=$7 tenant=${tenant} application=${application} key_path=${8}"
+./provision-kafka --inventory=${1} --tags "${application}" -e "tenant_config_path=${2} project=$3 cloud=$4 region=$5 domain=$6 cluster=$7 tenant=${tenant} application=${application} key_path=${8}"

--- a/provision-kafka
+++ b/provision-kafka
@@ -1,11 +1,11 @@
 #!/usr/bin/env ansible-playbook
 # (c) 2018 DataNexus Inc.  All Rights Reserved.
 #
-# main routine for provisioning confluent kafka
+# main routine for provisioning kafka
 ---   
 # note that the tags are not currently used, but are present for future integration into
 # the datanexus infrastructure components  
-- name: CONFLUENT OVERLAY | discovering {{ cloud }} networking
+- name: KAFKA OVERLAY | discovering {{ cloud }} networking
   tags:
     - confluent
   hosts: localhost
@@ -24,7 +24,7 @@
         tasks_from: discover-resourcegroup
       when: cloud == 'azure'
 
-- name: CONFLUENT OVERLAY | creating {{ cloud }} security groups
+- name: KAFKA OVERLAY | creating {{ cloud }} security groups
   tags:
     - confluent
   hosts: localhost
@@ -36,7 +36,7 @@
         tasks_from: create-securitygroup
       when: cloud == 'aws'
 
-- name: CONFLUENT OVERLAY | applying {{ cloud }} security groups
+- name: KAFKA OVERLAY | applying {{ cloud }} security groups
   tags:
     - confluent
   hosts: localhost
@@ -56,8 +56,8 @@
       when: cloud == 'azure'
 
 # complete preflight for all host groups
-- name: CONFLUENT OVERLAY | completing preflight OS configuration
-  hosts: zookeeper:kafka_broker:registry:controlcenter:kafka_connect:rest_proxy:kafka_ksql:kafka_replicator
+- name: KAFKA OVERLAY | completing preflight OS configuration
+  hosts: zookeeper:kafka_broker:registry:cruisecontrol:controlcenter:kafka_connect:rest_proxy:kafka_ksql:kafka_replicator
   tags:
     - confluent
   vars_files:
@@ -76,7 +76,11 @@
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/kafka/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/cruisecontrol.yml"
+    - "{{ tenant_config_path }}/config/applications/confluent.yml"
+    - "{{ tenant_config_path }}/config/applications/apache.yml"
   vars:
       # this is semi clever; application gets set based on each host group
       application: "{{ group_names | first }}"
@@ -84,100 +88,129 @@
   tasks:
     - include_role:
         name: cruisecontrol
-  
-- name: CONFLUENT OVERLAY | installing confluent platform across all nodes
+
+- name: KAFKA OVERLAY | installing platform across all nodes
   hosts: zookeeper:kafka_broker:registry:controlcenter:kafka_connect:rest_proxy:kafka_ksql:kafka_replicator
   tags:
     - confluent
   vars_files:
      - "{{ tenant_config_path }}/config/applications/confluent.yml"
+     - "{{ tenant_config_path }}/config/applications/apache.yml"
   gather_facts: yes
   tasks:
-    # here we want to configure platform or community based on confluent.yml
-    - set_fact:
-        confluent_distribution: "{{ (confluent_community == true) | ternary('confluent-community','confluent-platform') }}"
-
+    
     - import_role:
-        name: confluent
+        name: apache
+      when:
+        - apache_kafka
+        - not confluent_kafka
+        
+    - block:
 
-- name: CONFLUENT OVERLAY | configuring confluent zookeeper
+      # here we want to configure platform or community based on confluent.yml
+      - set_fact:
+          confluent_distribution: "{{ (confluent_community == true) | ternary('confluent-community','confluent-platform') }}"
+          
+      - import_role:
+          name: confluent
+          
+      when:
+        - confluent_kafka
+        - not apache_kafka
+
+- name: KAFKA OVERLAY | configuring zookeeper
   hosts: zookeeper
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/zookeeper.yml"
+    - "{{ tenant_config_path }}/config/applications/confluent.yml"
+    - "{{ tenant_config_path }}/config/applications/apache.yml"
   gather_facts: yes
   tasks:
     - import_role:
         name: zookeeper
 
 # this is necessary before we build host groups from the ansible server
-- name: CONFLUENT OVERLAY | discovering kafka broker facts
+- name: KAFKA OVERLAY | discovering kafka broker facts
   tags:
     - confluent
   hosts: kafka_broker
   tasks:
     - setup:
 
-- name: CONFLUENT OVERLAY | building kafka public internal host group
+- name: KAFKA OVERLAY | building kafka public internal host group
   tags:
     - confluent
   hosts: localhost
   gather_facts: no
   tasks:
-    - name: CONFLUENT OVERLAY | building kafka public internal host group
+    - name: KAFKA OVERLAY | building kafka public internal host group
       add_host: hostname="{{ hostvars[item].ansible_eth1.ipv4.address }}" groupname=kafka_public
       with_items: "{{ groups['kafka_broker'] }}"
       when: "'kafka_broker' in groups | default([])"
 
-- name: CONFLUENT OVERLAY | configuring confluent kafka
+- name: KAFKA OVERLAY | configuring kafka
   hosts: kafka_broker
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/zookeeper/defaults/main.yml
+    - roles/cruisecontrol/defaults/main.yml
+    - "{{ tenant_config_path }}/config/applications/apache.yml"
+    - "{{ tenant_config_path }}/config/applications/confluent.yml"
     - "{{ tenant_config_path }}/config/applications/kafka.yml"
   tasks:
     - import_role:
         name: kafka
             
-- name: CONFLUENT OVERLAY | configuring confluent schema registry
+- name: KAFKA OVERLAY | configuring confluent schema registry
   hosts: registry
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/zookeeper/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/registry.yml"
   tasks:
     - import_role:
         name: registry
 
-- name: CONFLUENT OVERLAY | building kafka ksql public internal host group
+- name: KAFKA OVERLAY | building kafka ksql public internal host group
   tags:
     - confluent
   hosts: localhost
   gather_facts: no
   tasks:
-    - name: CONFLUENT OVERLAY | building kafka ksql public internal host group
+    - name: KAFKA OVERLAY | building kafka ksql public internal host group
       add_host: hostname="{{ hostvars[item].ansible_eth1.ipv4.address }}" groupname=kafka_ksql_public
       with_items: "{{ groups['kafka_ksql'] }}"
       when: "'kafka_ksql' in groups | default([])"
 
-- name: CONFLUENT OVERLAY | building kafka connect public internal host group
+- name: KAFKA OVERLAY | building kafka connect public internal host group
   tags:
     - confluent
   hosts: localhost
   gather_facts: no
   tasks:
-    - name: CONFLUENT OVERLAY | retrieving data network ip address
+    - name: KAFKA OVERLAY | retrieving data network ip address
       add_host: hostname="{{ hostvars[item].ansible_eth1.ipv4.address }}" groupname=kafka_connect_public
       with_items: "{{ groups['kafka_connect'] }}"
       when: "'kafka_connect' in groups | default([])"
 
-- name: CRUISE CONTROL OVERLAY | configuring cruise control
+- name: CRUISE CONTROL OVERLAY | configuring linkedin cruise control
   hosts: cruisecontrol
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/zookeeper/defaults/main.yml
+    - roles/kafka/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/cruisecontrol.yml"
+    - "{{ tenant_config_path }}/config/applications/confluent.yml"
+    - "{{ tenant_config_path }}/config/applications/apache.yml"
   vars:
       # this is semi clever; application gets set based on each host group
       application: "{{ group_names | first }}"
@@ -186,29 +219,40 @@
     - include_role:
         name: cruisecontrol
         
-- name: CONFLUENT OVERLAY | configuring confluent controlcenter
+- name: KAFKA OVERLAY | configuring confluent controlcenter
   hosts: controlcenter
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/confluent/defaults/main.yml
+    - roles/zookeeper/defaults/main.yml
+    - roles/kafka/defaults/main.yml
+    - roles/connect/defaults/main.yml
+    - roles/ksql/defaults/main.yml
+    - roles/registry/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/controlcenter.yml"
   gather_facts: yes
   tasks:
     - import_role:
         name: controlcenter
 
-- name: CONFLUENT OVERLAY | configuring confluent kafka connect
+- name: KAFKA OVERLAY | configuring kafka connect
   hosts: kafka_connect
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/kafka/defaults/main.yml
+    - "{{ tenant_config_path }}/config/applications/apache.yml"
+    - "{{ tenant_config_path }}/config/applications/confluent.yml"
     - "{{ tenant_config_path }}/config/applications/connect.yml"
   gather_facts: yes
   tasks:
     - import_role:
         name: connect
 
-- name: CONFLUENT OVERLAY | configuring confluent kafka ReST proxy
+- name: KAFKA OVERLAY | configuring confluent kafka ReST proxy
   hosts: rest_proxy
   tags:
     - confluent
@@ -219,22 +263,29 @@
     - import_role:
         name: kafkarest
 
-- name: CONFLUENT OVERLAY | configuring confluent kafka ksql
+- name: KAFKA OVERLAY | configuring confluent kafka ksql
   hosts: kafka_ksql
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/kafka/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/ksql.yml"
   gather_facts: yes
   tasks:
     - import_role:
         name: ksql
 
-- name: CONFLUENT OVERLAY | completing postflight actions
-  hosts: zookeeper:kafka_broker:registry:controlcenter:kafka_connect:rest_proxy:kafka_ksql:kafka_replicator
+- name: KAFKA OVERLAY | completing postflight actions
+  hosts: zookeeper:kafka_broker:registry:kafka_connect:rest_proxy:kafka_ksql:kafka_replicator
   tags:
     - confluent
   vars_files:
+    - roles/apache/defaults/main.yml
+    - roles/kafka/defaults/main.yml
+    - roles/zookeeper/defaults/main.yml
+    - "{{ tenant_config_path }}/config/applications/apache.yml"
+    - "{{ tenant_config_path }}/config/applications/confluent.yml"
     - "{{ tenant_config_path }}/config/applications/postflight.yml"
   vars:
       # this is semi clever; application gets set based on each host group

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -1,0 +1,12 @@
+# (c) 2018 DataNexus Inc.  All Rights Reserved.
+---
+packages:
+  epel_version: '7-11'
+  java_version: '1.8.0'
+  kafka_version: '2.1.1'
+  scala_version: '2.12'
+apache:
+  install_dir: /usr/local
+  user: kafka
+  group: kafka
+  config_file: server.properties

--- a/roles/apache/handlers/main.yml
+++ b/roles/apache/handlers/main.yml
@@ -1,0 +1,9 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+# handlers used during apache installation
+---
+- name: yum-clean-all
+  command: /usr/bin/yum clean all
+  args:
+      warn: no
+  become: true

--- a/roles/apache/tasks/install-java.yml
+++ b/roles/apache/tasks/install-java.yml
@@ -1,0 +1,12 @@
+# (c) Copyright 2019 DataNexus Inc.  All Rights Reserved.
+#
+# install java
+---
+- name: KAFKA OVERLAY | installing java {{ packages.java_version }} packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "epel-release-{{ packages.epel_version }}"
+    - "java-{{ packages.java_version }}-openjdk"
+    - "java-{{ packages.java_version }}-openjdk-devel"

--- a/roles/apache/tasks/main.yml
+++ b/roles/apache/tasks/main.yml
@@ -1,0 +1,51 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+#
+---
+# CentOS / Redhat 7
+- block:
+  
+  - import_tasks: install-java.yml
+  
+  - name: KAFKA OVERLAY | adding {{ apache.group }} group
+    group:
+      name: "{{ apache.group }}"
+      
+  - name: KAFKA OVERLAY | adding {{ apache.user }} user
+    user:
+      name: "{{ apache.user }}"
+      group: "{{ apache.group }}"
+      
+  become: yes
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+
+- name: KAFKA OVERLAY | checking for {{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/config/{{ apache.config_file }}
+  stat: path="{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/config/{{ apache.config_file }}"
+  register: existing_package
+
+- block:
+
+  - name: KAFKA OVERLAY | fetching apache kafka v{{ application_version | default(packages.kafka_version) }}
+    get_url:
+      url: "http://www.gtlib.gatech.edu/pub/apache/kafka/{{ packages.kafka_version }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}.tgz"
+      dest: "/tmp/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}.tgz"
+      mode: 0640
+  
+  - name: KAFKA OVERLAY | installing kafka {{ application_version | default(packages.kafka_version) }}
+    unarchive:
+      src: "/tmp/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}.tgz"
+      dest: "{{ apache.install_dir }}"
+      owner: "{{ apache.user }}"
+      group: "{{ apache.group }}"
+      remote_src: yes
+  
+  - name: KAFKA OVERLAY | ensuring kafka configuration directory exists
+    file:
+      path: /usr/local/bin
+      state: directory
+      mode: 0755
+      owner: root
+      group: root
+
+  become: yes
+  when: not existing_package.stat.exists

--- a/roles/confluent/defaults/main.yml
+++ b/roles/confluent/defaults/main.yml
@@ -4,6 +4,8 @@ packages:
   epel_version: '7-11'
   java_version: '1.8.0'
   confluent_version: '5.1'
+  # kafka_version isn't used under confluent, here mainly to match apache
+  kafka_version: '2.1'
   scala_version: '2.11'
 confluent_os_releasever: '7'
 confluent_public_key: "https://packages.confluent.io/rpm/{{ packages.confluent_version }}/archive.key"

--- a/roles/connect/defaults/main.yml
+++ b/roles/connect/defaults/main.yml
@@ -1,16 +1,24 @@
 # configuration variables for kafka distributed connector services
 connect:
   distributed:
-    config_file: /etc/kafka/connect-distributed.properties
-    service_name: confluent-kafka-connect
-    systemd_override: /etc/systemd/system/confluent-kafka-connect.service.d
+    apache:
+      config_file: "{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/config/connect-distributed.properties"
+      service_name: apache-kafka-connect
+      systemd_override: /etc/systemd/system/apache-kafka-connect.service.d
+      user: kafka
+      group: kafka
+    confluent:
+      config_file: /etc/kafka/connect-distributed.properties
+      service_name: confluent-kafka-connect
+      systemd_override: /etc/systemd/system/confluent-kafka-connect.service.d
+      user: cp-kafka-connect
+      group: confluent
     user_service: /usr/local/bin
-    user: cp-kafka-connect
-    group: confluent
     environment:
       KAFKA_HEAP_OPTS: "-Xms256M -Xmx{{ jvm_heap_mem }}g"
+      LOG_DIR: /var/log/kafka
     config:
-      rest_port: 8083
+      rest_port: '8083'
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
       ssl.endpoint.identification.algorithm: ""
@@ -28,7 +36,3 @@ connect:
       offset_storage_topic: connect-offsets
       status_storage_replication_factor: 3
       status_storage_topic: connect-status
-broker:
-   config:
-     # if this gets changed it needs to be changed under kafka defaults
-     broker_port: '9092'

--- a/roles/connect/handlers/main.yml
+++ b/roles/connect/handlers/main.yml
@@ -8,6 +8,6 @@
   
 - name: restart connect
   systemd:
-    name: "{{ connect.distributed.service_name }}"
+    name: "{{ connect_service_name }}"
     state: restarted
   become: yes

--- a/roles/connect/tasks/main.yml
+++ b/roles/connect/tasks/main.yml
@@ -5,119 +5,131 @@
 - import_tasks: tune.yml
 
 - import_tasks: interface-facts.yml
+
+- set_fact: 
+    connect_user: "{{ (apache_kafka) | ternary(connect.distributed.apache.user, connect.distributed.confluent.user) }}"
+
+- set_fact: 
+     connect_group: "{{ (apache_kafka) | ternary(connect.distributed.apache.group, connect.distributed.confluent.group) }}"
   
+- set_fact: 
+    connect_service_name: "{{ (apache_kafka) | ternary(connect.distributed.apache.service_name, connect.distributed.confluent.service_name) }}"
+
+- set_fact: 
+    connect_config_file: "{{ (apache_kafka) | ternary(connect.distributed.apache.config_file, connect.distributed.confluent.config_file) }}"
+    
 - block:
   
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring bootstrap servers for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring bootstrap servers for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^bootstrap.servers='
-      line: "bootstrap.servers={{ groups['kafka_public'] | join(':' + broker.config.broker_port + ',') }}:{{ broker.config.broker_port }}"
+      line: "bootstrap.servers={{ groups['kafka_public'] | join(':' + kafka.config.broker_port + ',') }}:{{ kafka.config.broker_port }}"
     notify: restart connect
     
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring cluster group id for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring cluster group id for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^group.id='
       line: "group.id={{ connect.distributed.config.group_id }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring key converter for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring key converter for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^key.converter='
       line: "key.converter={{ connect.distributed.config.key_converter }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring value converter for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring value converter for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^value.converter='
       line: "value.converter={{ connect.distributed.config.value_converter }}"
     notify: restart connect
             
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring key converter schema enablement for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring key converter schema enablement for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^key.converter.schemas.enable='
       line: "key.converter.schemas.enable={{ connect.distributed.config.key_converter_schemas_enable }}"
     notify: restart connect
             
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring value converter schema enablement for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring value converter schema enablement for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^value.converter.schemas.enable='
       line: "value.converter.schemas.enable={{ connect.distributed.config.value_converter_schemas_enable }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring storage offset topic for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring storage offset topic for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^offset.storage.topic='
       line: "offset.storage.topic={{ connect.distributed.config.offset_storage_topic }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring storage offset topic replication factor for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring storage offset topic replication factor for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^offset.storage.replication.factor='
       line: "offset.storage.replication.factor={{ connect.distributed.config.offset_storage_replication_factor }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring storage offset topic for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring storage offset topic for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^config.storage.topic='
       line: "config.storage.topic={{ connect.distributed.config.config_storage_topic }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring storage offset topic replication factor for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring storage offset topic replication factor for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^config.storage.replication.factor='
       line: "config.storage.replication.factor={{ connect.distributed.config.config_storage_replication_factor }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring status storage topic for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring status storage topic for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^status.storage.topic='
       line: "status.storage.topic={{ connect.distributed.config.status_storage_topic }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring status storage topic replication factor for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring status storage topic replication factor for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^status.storage.replication.factor='
       line: "status.storage.replication.factor={{ connect.distributed.config.status_storage_replication_factor }}"
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring offset flush interval for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | configuring offset flush interval for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^offset.flush.interval.ms='
       line: "offset.flush.interval.ms={{ connect.distributed.config.offset_flush_interval_ms }}"
     notify: restart connect
 
-  - name: CONFLUENT OVERLAY (CONNECT) | enabling and configuring ReST host for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | enabling and configuring ReST host for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^rest.host.name='
       line: "rest.host.name={{ connector_rest_interface_ipv4 }}"
       insertafter: '^#rest.host.name='
     notify: restart connect
 
-  - name: CONFLUENT OVERLAY (CONNECT) | enabling and configuring ReST port for {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | enabling and configuring ReST port for {{ connect_service_name }}
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^rest.port='
       line: "rest.port={{ connect.distributed.config.rest_port }}"
       insertafter: '^#rest.port='
     notify: restart connect
         
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring kafka connect properties for consumer interceptors for control center
+  - name: KAFKA OVERLAY (CONNECT) | configuring kafka connect properties for consumer interceptors for control center
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^consumer.interceptor.classes='
       line: 'consumer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor'
     when:
@@ -125,9 +137,9 @@
       - groups['controlcenter'] | length > 0
     notify: restart connect
 
-  - name: CONFLUENT OVERLAY (CONNECT) | configuring kafka connect properties for producers interceptors for control center
+  - name: KAFKA OVERLAY (CONNECT) | configuring kafka connect properties for producers interceptors for control center
     lineinfile:
-      path: "{{ connect.distributed.config_file }}"
+      path: "{{ connect_config_file }}"
       regexp: '^producer.interceptor.classes='
       line: 'producer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor'
     when:
@@ -135,7 +147,7 @@
       - groups['controlcenter'] | length > 0
     notify: restart connect
   
-  - name: CONFLUENT OVERLAY (CONNECT) | ensuring {{ connect.distributed.user_service }} exists
+  - name: KAFKA OVERLAY (CONNECT) | ensuring {{ connect.distributed.user_service }} exists
     file:
       path: "{{ connect.distributed.user_service }}"
       owner: root
@@ -143,57 +155,87 @@
       state: directory
       mode: 0755
 
-  - name: CONFLUENT OVERLAY (CONNECT) | ensuring /var/log/kafka exists
+  - name: KAFKA OVERLAY (CONNECT) | ensuring {{ connect.distributed.environment.LOG_DIR }} exists
     file:
-      path: /var/log/kafka
-      owner: "{{ connect.distributed.user }}"
-      group: "{{ connect.distributed.group }}"
+      path: "{{ connect.distributed.environment.LOG_DIR }}"
+      owner: "{{ connect_user }}"
+      group: "{{ connect_group }}"
       state: directory
       mode: 0755
       
   # this is datanexus original logging, so we need to make sure it exists since it's not handled via standard install
-  - name: CONFLUENT OVERLAY (CONNECT) | ensuring /var/log/kafka/connect.log exists
+  - name: KAFKA OVERLAY (CONNECT) | ensuring {{ connect.distributed.environment.LOG_DIR }}/connect.log exists
     file:
-      path: /var/log/kafka/connect.log
-      owner: "{{ connect.distributed.user }}"
-      group: "{{ connect.distributed.group }}"
+      path: "{{ connect.distributed.environment.LOG_DIR }}/connect.log"
+      owner: "{{ connect_user }}"
+      group: "{{ connect_group }}"
       state: touch
-      mode: 0644   
+      mode: 0644
+  
+  - set_fact: 
+      connect_wrapper: "{{ (apache_kafka) | ternary('apache.connect.j2', 'confluent.connect.j2') }}"
       
-  - name: CONFLUENT OVERLAY (CONNECT) | installing {{ connect.distributed.service_name }} into {{ connect.distributed.user_service }}
+  - name: KAFKA OVERLAY (CONNECT) | installing {{ connect_service_name }} into {{ connect.distributed.user_service }}
     template:
-      src: confluent.connect.j2
-      dest: "{{ connect.distributed.user_service }}/confluent-kafka-connect"
+      src: "{{ connect_wrapper }}"
+      dest: "{{ connect.distributed.user_service }}/kafka-connect"
       mode: 0755
-      owner: "{{ connect.distributed.user }}"
-      group: "{{ connect.distributed.group }}"
+      owner: "{{ connect_user }}"
+      group: "{{ connect_group }}"
     
   become: yes
  
 - block:
   
-  - name: CONFLUENT OVERLAY (CONNECT) | creating systemd override directory
+  - block:
+        
+    - name: KAFKA OVERLAY (CONNECT) | installing systemd {{ connect_service_name }} script
+      template:
+        src: apache-kafka.service.j2
+        dest: "/etc/systemd/system/{{ connect_service_name }}.service"
+        mode: 0640
+        owner: "{{ connect_user }}"
+        group: "{{ connect_group }}"
+      notify:
+        - reload systemd
+    
+    - name: KAFKA OVERLAY (CONNECT) | enabling {{ connect_service_name }}
+      systemd:
+        name: "{{ connect_service_name }}.service"
+        enabled: yes
+        
+    when:
+      - apache_kafka
+      - not confluent_kafka
+      
+  - set_fact: 
+      connect_override_name: "{{ (apache_kafka) | ternary(connect.distributed.apache.systemd_override, connect.distributed.confluent.systemd_override) }}"
+      
+  - name: KAFKA OVERLAY (CONNECT) | creating systemd override directory
     file:
-      path: "{{ connect.distributed.systemd_override }}"
-      owner: "{{ connect.distributed.user }}"
-      group: "{{ connect.distributed.group }}"
+      path: "{{ connect_override_name }}"
+      owner: "{{ connect_user }}"
+      group: "{{ connect_group }}"
       state: directory
       mode: 0750
  
-  - name: CONFLUENT OVERLAY (CONNECT) | installing {{ connect.distributed.service_name }} environment overrride
+  - set_fact:
+      connect_override_name: "{{ (apache_kafka) | ternary(connect.distributed.apache.systemd_override, connect.distributed.confluent.systemd_override) }}"
+   
+  - name: KAFKA OVERLAY (CONNECT) | installing {{ connect_service_name }} environment overrride
     template:
       src: environment.j2
-      dest: "{{ connect.distributed.systemd_override }}/override.conf"
+      dest: "{{ connect_override_name }}/override.conf"
       mode: 0640
-      owner: "{{ connect.distributed.user }}"
-      group: "{{ connect.distributed.group }}"
+      owner: "{{ connect_user }}"
+      group: "{{ connect_group }}"
     notify:
       - reload systemd
       - restart connect
   
-  - name: CONFLUENT OVERLAY (CONNECT) | starting {{ connect.distributed.service_name }}
+  - name: KAFKA OVERLAY (CONNECT) | starting {{ connect_service_name }}
     systemd:
-      name: "{{ connect.distributed.service_name }}"
+      name: "{{ connect_service_name }}"
       state: started
       
   become: yes

--- a/roles/connect/templates/apache-kafka.service.j2
+++ b/roles/connect/templates/apache-kafka.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Apache Kafka Connect
+Documentation=https://kafka.apache.org
+After=network.target remote-fs.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}
+User={{ connect_user }}
+Group={{ connect_user }}
+ExecStart={{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/connect-distributed.sh {{ connect_config_file }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/connect/templates/apache.connect.j2
+++ b/roles/connect/templates/apache.connect.j2
@@ -11,7 +11,7 @@ if [ "$1" = "start" ] ; then
   {% for key, value in connect.distributed.environment.items() -%}
   {{ " " ~ key }}="{{ value }}"
   {%- endfor %}
-  /usr/bin/nohup /usr/bin/connect-distributed {{ connect_config_file }} >> {{ connect.distributed.environment.LOG_DIR }}/connect.log 2>&1 &
+  /usr/bin/nohup {{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/connect-distributed.sh {{ connect_config_file }} >> {{ connect.distributed.environment.LOG_DIR }}/connect.log 2>&1 &
 elif [ "$1" = "stop" ] ; then
   SIGNAL=${SIGNAL:-TERM}
   PIDS=$(ps ax | grep -i 'kafka\.connect' | grep java | grep -v grep | awk '{print $1}')

--- a/roles/controlcenter/defaults/main.yml
+++ b/roles/controlcenter/defaults/main.yml
@@ -15,24 +15,3 @@ control:
       confluent_license: /etc/confluent-control-center/license
       confluent.controlcenter.streams.ssl.endpoint.identification.algorithm: ""
       confluent.controlcenter.rest.ssl.endpoint.identification.algorithm: ""
-zookeeper:
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it needs to be changed under zookeeper defaults
-    port: '2181'
-kafkabroker:
-  service_name: confluent-kafka
-  config:
-    # if this gets changed it needs to be changed under kafka defaults
-    broker_port: '9092'
-ksql:
-  config:
-    listener_port: '8088'
-schema:
-  registry:
-    config:
-      schema_registry_listener_port: '8081'
-connect:
-  distributed:
-    config:
-      listener_port: '8083'

--- a/roles/controlcenter/tasks/main.yml
+++ b/roles/controlcenter/tasks/main.yml
@@ -10,7 +10,7 @@
     lineinfile:
       path: "{{ control.center.config_file }}"
       regexp: '^bootstrap.servers='
-      line: "bootstrap.servers={{ groups['kafka_public'] | join(':' + kafkabroker.config.broker_port + ',') }}:{{ kafkabroker.config.broker_port }}"
+      line: "bootstrap.servers={{ groups['kafka_public'] | join(':' + kafka.config.broker_port + ',') }}:{{ kafka.config.broker_port }}"
       insertafter: '^#bootstrap.servers='
     notify: restart controlcenter
     
@@ -57,7 +57,7 @@
     lineinfile:
       path: "{{ control.center.config_file }}"
       regexp: '^confluent.controlcenter.connect.cluster='
-      line: "confluent.controlcenter.connect.cluster=http://{{ groups['kafka_connect_public'] | join(':' + connect.distributed.config.listener_port + ',http://') }}:{{ connect.distributed.config.listener_port }}"
+      line: "confluent.controlcenter.connect.cluster=http://{{ groups['kafka_connect_public'] | join(':' + connect.distributed.config.rest_port + ',http://') }}:{{ connect.distributed.config.rest_port }}"
       insertafter: '^#confluent.controlcenter.connect.cluster='
     when:
       - groups['kafka_connect_public'] is defined

--- a/roles/cruisecontrol/defaults/main.yml
+++ b/roles/cruisecontrol/defaults/main.yml
@@ -7,22 +7,10 @@ cruisecontrol:
   ui_config_file: /usr/local/src/cruise-control/cruise-control-ui/dist/static/config.csv
   service_name: cruise-control
   user_service: /usr/local/bin
-  user: "{{ ansible_user }}"
-  group: "{{ ansible_user }}"
-  environment:
+  # environment:
   config:
     port: '9090'
     log: /var/log/linkedin/cruise-control
-# defaults for various packages
-packages:
-  epel_version: '7-11'
-  java_version: '1.8.0'
-  gradle_version: '5.2.1'
-zookeeper:
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it needs to be changed under zookeeper defaults
-    port: '2181'
-kafka:
-  config:
-    broker_port: '9092'
+  packages:
+    gradle_version: '5.2.1'
+  

--- a/roles/cruisecontrol/tasks/install-gradle.yml
+++ b/roles/cruisecontrol/tasks/install-gradle.yml
@@ -2,16 +2,16 @@
 #
 # install gradle from binaries
 ---
-- name: CRUISE CONTROL GRADLE OVERLAY | checking for /tmp/gradle-{{ gradle_version | default(packages.gradle_version) }}-bin.zip existence
-  stat: path="/tmp/gradle-{{ gradle_version | default(packages.gradle_version) }}-bin.zip"
+- name: CRUISE CONTROL GRADLE OVERLAY | checking for /tmp/gradle-{{ gradle_version | default(cruisecontrol.packages.gradle_version) }}-bin.zip existence
+  stat: path="/tmp/gradle-{{ gradle_version | default(cruisecontrol.packages.gradle_version) }}-bin.zip"
   register: existing_package
 
 - block:
   
-  - name: CRUISE CONTROL GRADLE OVERLAY | downloading gradle version {{ gradle_version | default(packages.gradle_version) }}.tar.gz
+  - name: CRUISE CONTROL GRADLE OVERLAY | downloading gradle version {{ gradle_version | default(cruisecontrol.packages.gradle_version) }}.tar.gz
     get_url:
-      url: "https://services.gradle.org/distributions/gradle-{{ gradle_version | default(packages.gradle_version) }}-bin.zip"
-      dest: "/tmp/gradle-{{ gradle_version | default(packages.gradle_version) }}-bin.zip"
+      url: "https://services.gradle.org/distributions/gradle-{{ gradle_version | default(cruisecontrol.packages.gradle_version) }}-bin.zip"
+      dest: "/tmp/gradle-{{ gradle_version | default(cruisecontrol.packages.gradle_version) }}-bin.zip"
       mode: 0600
   
   when: not existing_package.stat.exists
@@ -20,7 +20,7 @@
   
   - name: CRUISE CONTROL OVERLAY | installing gradle
     unarchive:
-      src: "/tmp/gradle-{{ gradle_version | default(packages.gradle_version) }}-bin.zip"
+      src: "/tmp/gradle-{{ gradle_version | default(cruisecontrol.packages.gradle_version) }}-bin.zip"
       dest: "{{ source_dir }}"
       owner: root
       group: root
@@ -32,7 +32,7 @@
 - name: CRUISE CONTROL GRADLE OVERLAY | updating {{ ansible_user }} environment variables
   lineinfile:
     path: "/home/{{ ansible_user }}/.zshrc"
-    line: "export GRADLE_HOME={{ source_dir }}/gradle-{{ gradle_version | default(packages.gradle_version) }}"
+    line: "export GRADLE_HOME={{ source_dir }}/gradle-{{ gradle_version | default(cruisecontrol.packages.gradle_version) }}"
     
 - name: CRUISE CONTROL GRADLE OVERLAY | updating {{ ansible_user }} path
   lineinfile:

--- a/roles/cruisecontrol/tasks/main.yml
+++ b/roles/cruisecontrol/tasks/main.yml
@@ -2,16 +2,38 @@
 #
 # cruise control installation: https://github.com/linkedin/cruise-control
 ---
-- import_tasks: interface-facts.yml
+# this isn't strictly necessary for cruise control, but the kafka broker default variables need JVM settings
+- import_tasks: tune.yml
 
-# create all the required directories and files
+- import_tasks: interface-facts.yml
+  
+- set_fact: 
+    cruisecontrol_user: "{{ (apache_kafka) | ternary(kafka.apache.user, kafka.confluent.user) }}"
+
+- set_fact:
+    cruisecontrol_group: "{{ (apache_kafka) | ternary(kafka.apache.group, kafka.confluent.group) }}"
+
+# create all the required directories and files   
 - block:
   
+  - import_tasks: install-git.yml
+  - import_tasks: install-java.yml
+  
+  # this is a bit of a hack, but we want files owned by a consistent user/group across the platform
+  - name: CRUISE CONTROL OVERLAY | adding {{ cruisecontrol_group }} group
+    group:
+      name: "{{ cruisecontrol_group }}"
+  
+  - name: CRUISE CONTROL OVERLAY | adding {{ cruisecontrol_user }} user
+    user:
+      name: "{{ cruisecontrol_user }}"
+      group: "{{ cruisecontrol_group }}"
+        
   - name: CRUISE CONTROL OVERLAY | ensuring {{ cruisecontrol_log_dir | default(cruisecontrol.config.log) }} exists and has the correct permissions for {{ cruisecontrol.service_name }}
     file:
       path: "{{ cruisecontrol_log_dir | default(cruisecontrol.config.log) }}"
-      owner: "{{ cruisecontrol.user }}"
-      group: "{{ cruisecontrol.group }}"
+      owner: "{{ cruisecontrol_user }}"
+      group: "{{ cruisecontrol_group }}"
       state: directory
       mode: 0750
       
@@ -28,8 +50,8 @@
       src: linkedin.cruisecontrol.j2
       dest: "{{ cruisecontrol.user_service }}/{{ cruisecontrol.service_name }}"
       mode: 0755
-      owner: "{{ cruisecontrol.user }}"
-      group: "{{ cruisecontrol.group }}"
+      owner: "{{ cruisecontrol_user }}"
+      group: "{{ cruisecontrol_group }}"
 
   become: yes
   
@@ -37,32 +59,28 @@
   stat:
     path: "{{ cruisecontrol.source_dir }}/cruise-control/cruise-control-metrics-reporter/build/libs/cruise-control-metrics-reporter-{{ application_version | default(cruisecontrol.version) }}.jar"
   register: metrics_jar
-
+  
 - block:
   
-  - import_tasks: install-git.yml
-  - import_tasks: install-java.yml
-    
   - name: CRUISE CONTROL OVERLAY | cloning cruise control {{ application_version | default(cruisecontrol.version) }}
     git:
       repo: 'https://github.com/linkedin/cruise-control.git'
       dest: "{{ cruisecontrol.source_dir }}/cruise-control"
       version: "{{ application_version | default(cruisecontrol.version) }}"
-    become: yes
 
   - name: CRUISE CONTROL OVERLAY | fixing permissions
     file:
       path: "{{ cruisecontrol.source_dir }}/cruise-control"
-      owner: "{{ ansible_user }}"
-      group: "{{ ansible_user }}"
+      owner: "{{ cruisecontrol_user }}"
+      group: "{{ cruisecontrol_group }}"
       recurse: yes
-    become: yes
   
   - name: CRUISE CONTROL OVERLAY | compiling cruise control {{ application_version | default(cruisecontrol.version) }}
     command: "./gradlew jar"
     args:
       chdir: "{{ cruisecontrol.source_dir }}/cruise-control"
-  
+    become_user: "{{ cruisecontrol_user }}"
+    
   - name: CRUISE CONTROL OVERLAY | fetching cruise control metrics jar
     fetch:
       src: "{{ cruisecontrol.source_dir }}/cruise-control/cruise-control-metrics-reporter/build/libs/{{ item }}"
@@ -70,7 +88,9 @@
       flat: yes
     with_items:
       - "cruise-control-metrics-reporter-{{ application_version | default(cruisecontrol.version) }}.jar"
+    become_user: "{{ cruisecontrol_user }}"
   
+  become: yes
   when: not metrics_jar.stat.exists
 
     
@@ -80,7 +100,9 @@
   - name: CRUISE CONTROL OVERLAY (FRONT END) | checking for {{ cruisecontrol.source_dir }}/cruise-control/cruise-control-ui
     stat: path="{{ cruisecontrol.source_dir }}/cruise-control/cruise-control-ui"
     register: existing_package
-
+    become: yes
+    become_user: "{{ cruisecontrol_user }}"
+    
   # https://github.com/linkedin/cruise-control-ui/
   - block:
 
@@ -95,9 +117,10 @@
       unarchive:
         src: /tmp/cruise-control-ui.tar.gz
         dest: "{{ cruisecontrol.source_dir }}/cruise-control"
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
+        owner: "{{ cruisecontrol_user }}"
+        group: "{{ cruisecontrol_group }}"
         remote_src: yes
+      become_user: "{{ cruisecontrol_user }}"
       when: not existing_package.stat.exists
 
     - name: CRUISE CONTROL OVERLAY (FRONT END) | setting {{ cruisecontrol.service_name }} network port to {{ cruisecontrol.config.port }}
@@ -122,6 +145,8 @@
         line: "{{ region }},{{ project }},/kafkacruisecontrol/"
       notify: restart cruisecontrol
   
+    become: yes
+    become_user: "{{ cruisecontrol_user }}"
     when: 
       - (frontend | default(cruisecontrol.frontend))
       
@@ -131,6 +156,8 @@
       regexp: '^bootstrap.servers='
       line: "bootstrap.servers={{ groups['kafka_public'] | join(':' + kafka.config.broker_port + ',') }}:{{ kafka.config.broker_port }}"
     notify: restart cruisecontrol
+    become: yes
+    become_user: "{{ cruisecontrol_user }}"
     
   - name: CRUISE CONTROL OVERLAY | configuring zookeeper hosts
     lineinfile:
@@ -138,11 +165,15 @@
       regexp: '^zookeeper.connect='
       line: "zookeeper.connect={{ groups['zookeeper'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
     notify: restart cruisecontrol
+    become: yes
+    become_user: "{{ cruisecontrol_user }}"
     
   - name: CRUISE CONTROL OVERLAY | copying cruise control libs
     command: "./gradlew jar copyDependantLibs"
     args:
       chdir: "{{ cruisecontrol.source_dir }}/cruise-control"
+    become: yes
+    become_user: "{{ cruisecontrol_user }}"
   
   - block:
   
@@ -166,7 +197,7 @@
     become: yes
     when:
       - ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
-  
+
   when:
     - groups['kafka_public'] is defined
     - groups['kafka_public'] | length > 0

--- a/roles/cruisecontrol/tasks/tune.yml
+++ b/roles/cruisecontrol/tasks/tune.yml
@@ -1,0 +1,20 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+#
+---
+- name: CRUISE CONTROL OVERLAY (JVM TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
+  set_fact:
+    heap_req="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int)) }}"    
+
+# this calculates half the total memory (rounded down) for the JVM; for kafka brokers this should max out at 5g
+- name: CRUISE CONTROL OVERLAY (JVM TUNING) | setting jvm heap to {{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}g
+  set_fact: jvm_heap_mem="{{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}"
+
+- name: CRUISE CONTROL OVERLAY (JVM TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) }}gb total
+  assert:
+    that:
+      - (jvm_heap_mem | int) <= ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) 
+    fail_msg: "heap space inadequate: allocate more RAM, decrease requested heap space, or set 'jvm_heap' to 'auto'"
+    success_msg: "system has enough heap space"
+
+  

--- a/roles/cruisecontrol/templates/cruisecontrol.service.j2
+++ b/roles/cruisecontrol/templates/cruisecontrol.service.j2
@@ -6,8 +6,8 @@ After=network.target remote-fs.target
 [Service]
 Type=simple
 WorkingDirectory={{ cruisecontrol.source_dir}}/{{ cruisecontrol.service_name}}
-User={{ cruisecontrol.user }}
-Group={{ cruisecontrol.user }}
+User={{ cruisecontrol_user }}
+Group={{ cruisecontrol_group }}
 ExecStart={{ cruisecontrol.source_dir }}/{{ cruisecontrol.service_name}}/kafka-cruise-control-start.sh {{ cruisecontrol.config_file }}
 
 [Install]

--- a/roles/cruisecontrol/templates/linkedin.cruisecontrol.j2
+++ b/roles/cruisecontrol/templates/linkedin.cruisecontrol.j2
@@ -2,7 +2,7 @@
 
 if [ $# -eq 0 ] || [ "$1" = "-h" ] ; then
 	printf "Usage:\\t{{ cruisecontrol.service_name}} [-h]\\thelp\\n"
-	printf "Usage:\\tsudo -H -u {{ cruisecontrol.user }} {{ cruisecontrol.user_service }}/{{ cruisecontrol.service_name}} [ start | stop | restart ]\\n"
+	printf "Usage:\\tsudo -H -u {{ cruisecontrol_user }} {{ cruisecontrol.user_service }}/{{ cruisecontrol.service_name}} [ start | stop | restart ]\\n"
 	exit 0
 fi
 

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,21 +1,22 @@
 # configuration variables for kafka broker services
-cruisecontrol:
-  version: '2.0.36'
-zookeeper:
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it needs to be changed under zookeeper defaults
-    port: '2181'
 kafka:
-  user: cp-kafka
-  group: confluent
-  config_file: /etc/kafka/server.properties
-  systemd_override: /etc/systemd/system/confluent-kafka.service.d
+  apache:
+    user: kafka
+    group: kafka
+    config_file: "{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/config/server.properties"
+    service_name: apache-kafka
+    systemd_override: /etc/systemd/system/apache-kafka.service.d
+  confluent:
+    user: cp-kafka
+    group: confluent
+    config_file: /etc/kafka/server.properties
+    systemd_override: /etc/systemd/system/confluent-kafka.service.d
+    service_name: confluent-kafka 
   user_service: /usr/local/bin
-  service_name: confluent-kafka
   environment:
     KAFKA_HEAP_OPTS: "-Xmx{{ jvm_heap_mem }}g -Xms{{ jvm_heap_mem }}g"
     KAFKA_JVM_PERFORMANCE_OPTS: "-XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
+    LOG_DIR: /var/log/kafka
     # this does not seem to work to eliminate the subject alternative name error
     # KAFKA_OPTS: "-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true"
     # uncomment the following line to turn on JMX on port 10101

--- a/roles/kafka/handlers/main.yml
+++ b/roles/kafka/handlers/main.yml
@@ -9,7 +9,7 @@
 - name: restart broker
   listen: "restart broker"
   systemd:
-    name: "{{ kafka.service_name }}"
+    name: "{{ broker_service_name }}"
     state: restarted
   become: true
 

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -6,187 +6,199 @@
 
 - import_tasks: interface-facts.yml
 
+- set_fact: 
+    broker_user: "{{ (apache_kafka) | ternary(kafka.apache.user, kafka.confluent.user) }}"
+
+- set_fact: 
+     broker_group: "{{ (apache_kafka) | ternary(kafka.apache.group, kafka.confluent.group) }}"
+  
+- set_fact: 
+    broker_service_name: "{{ (apache_kafka) | ternary(kafka.apache.service_name, kafka.confluent.service_name) }}"
+
+- set_fact: 
+    broker_config_file: "{{ (apache_kafka) | ternary(kafka.apache.config_file, kafka.confluent.config_file) }}"
+      
 - block:
 
-  - name: CONFLUENT OVERLAY (BROKER) | enabling topic deletion for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling topic deletion for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^delete.topic.enable='
       line: "delete.topic.enable={{ kafka.config.topic_deletion }}"
     when: not((kafka.config.topic_deletion is undefined) or (kafka.config.topic_deletion is none) or (kafka.config.topic_deletion | trim == ''))  
     notify: restart broker
     
   # we use backrefs here to ensure that the line only gets inserted as needed
-  - name: CONFLUENT OVERLAY (BROKER) | disabling manual {{ kafka.service_name }} ids
+  - name: KAFKA OVERLAY (BROKER) | disabling manual {{ broker_service_name }} ids
     lineinfile:
       backrefs: yes
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^broker.id='
       line: '#broker.id='
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | enabling dynamic ids for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling dynamic ids for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^broker.id.generation.enable='
       line: 'broker.id.generation.enable=true'
       insertafter: '^#broker.id'    
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} listeners
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} listeners
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^listeners='
       line: "listeners=PLAINTEXT://{{ kafka_interface_ipv4 }}:{{ kafka.config.broker_port }}"
       insertafter: '^#listeners='
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} advertised listeners
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} advertised listeners
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^advertised.listeners='
       line: "advertised.listeners=PLAINTEXT://{{ kafka_interface_ipv4 }}:{{ kafka.config.broker_port }}"
       insertafter: '^#advertised.listeners='
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} server network threads
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} server network threads
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^num.network.threads='
       line: "num.network.threads={{ kafka.config.num_network_threads }}"
     when: not((kafka.config.num_network_threads is undefined) or (kafka.config.num_network_threads is none) or (kafka.config.num_network_threads | trim == ''))
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} server io threads
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} server io threads
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^num.io.threads='
       line: "num.io.threads={{ kafka.config.num_io_threads }}"
     when: not((kafka.config.num_io_threads is undefined) or (kafka.config.num_io_threads is none) or (kafka.config.num_io_threads | trim == ''))
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} send buffer
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} send buffer
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^socket.send.buffer.bytes='
       line: "socket.send.buffer.bytes={{ kafka.config.socket_send_buffer_bytes }}"
     when: not((kafka.config.socket_send_buffer_bytes is undefined) or (kafka.config.socket_send_buffer_bytes is none) or (kafka.config.socket_send_buffer_bytes | trim == ''))
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} receive buffer
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} receive buffer
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^socket.receive.buffer.bytes='
       line: "socket.receive.buffer.bytes={{ kafka.config.socket_receive_buffer_bytes }}"
     when: not((kafka.config.socket_receive_buffer_bytes is undefined) or (kafka.config.socket_receive_buffer_bytes is none) or (kafka.config.socket_receive_buffer_bytes | trim == ''))
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} maximum size of an acceptable request
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} maximum size of an acceptable request
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^socket.request.max.bytes='
       line: "socket.request.max.bytes={{ kafka.config.socket_request_max_bytes }}"
     when: not((kafka.config.socket_request_max_bytes is undefined) or (kafka.config.socket_request_max_bytes is none) or (kafka.config.socket_request_max_bytes | trim == ''))
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | ensuring {{ kafka_log_dir | default(kafka.config.logDir) }} exists and has the correct permissions for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | ensuring {{ kafka_log_dir | default(kafka.config.logDir) }} exists and has the correct permissions for {{ broker_service_name }}
     file:
       path: "{{ item }}"
-      owner: "{{ kafka.user }}"
-      group: "{{ kafka.group }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
       state: directory
       mode: 0750
     with_items: "{{ kafka_log_dir | default(kafka.config.logDir) }}"
   
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} log directories
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} log directories
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.dirs='
       line: "log.dirs={{ kafka_log_dir | default(kafka.config.logDir) | join(',') }}"
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} default number of partitions
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} default number of partitions
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^num.partitions='
       line: "num.partitions={{ kafka.config.default_num_partitions }}"
     when: not((kafka.config.default_num_partitions is undefined) or (kafka.config.default_num_partitions is none) or (kafka.config.default_num_partitions | trim == ''))
     notify: restart broker
     
-  - name: CONFLUENT OVERLAY (BROKER) | configuring number of threads for {{ kafka.service_name }} data directory log recovery
+  - name: KAFKA OVERLAY (BROKER) | configuring number of threads for {{ broker_service_name }} data directory log recovery
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^num.recovery.threads.per.data.dir='
       line: "num.recovery.threads.per.data.dir={{ kafka.config.num_recovery_threads_per_data_dir }}"
     when: not((kafka.config.num_recovery_threads_per_data_dir is undefined) or (kafka.config.num_recovery_threads_per_data_dir is none) or (kafka.config.num_recovery_threads_per_data_dir | trim == ''))  
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring replication factor for {{ kafka.service_name }} group metadata internal topics
+  - name: KAFKA OVERLAY (BROKER) | configuring replication factor for {{ broker_service_name }} group metadata internal topics
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^offsets.topic.replication.factor='
       line: "offsets.topic.replication.factor={{ kafka.config.offsets_topic_replication_factor }}"
     when: not((kafka.config.offsets_topic_replication_factor is undefined) or (kafka.config.offsets_topic_replication_factor is none) or (kafka.config.offsets_topic_replication_factor | trim == ''))  
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring replication factor for {{ kafka.service_name }} transaction topic
+  - name: KAFKA OVERLAY (BROKER) | configuring replication factor for {{ broker_service_name }} transaction topic
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^transaction.state.log.replication.factor='
       line: "transaction.state.log.replication.factor={{ kafka.config.transaction_state_log_replication_factor }}"
     when: not((kafka.config.transaction_state_log_replication_factor is undefined) or (kafka.config.transaction_state_log_replication_factor is none) or (kafka.config.transaction_state_log_replication_factor | trim == ''))  
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | overriding min.insync.replicas for {{ kafka.service_name }} transaction topic
+  - name: KAFKA OVERLAY (BROKER) | overriding min.insync.replicas for {{ broker_service_name }} transaction topic
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^transaction.state.log.min.isr='
       line: "transaction.state.log.min.isr={{ kafka.config.transaction_state_log_min_isr }}"
     when: not((kafka.config.transaction_state_log_min_isr is undefined) or (kafka.config.transaction_state_log_min_isr is none) or (kafka.config.transaction_state_log_min_isr | trim == ''))  
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring minimum age for {{ kafka.service_name }} log deletion
+  - name: KAFKA OVERLAY (BROKER) | configuring minimum age for {{ broker_service_name }} log deletion
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.retention.hours='
       line: "log.retention.hours={{ kafka.config.log_retention_hours }}"
     when: not((kafka.config.log_retention_hours is undefined) or (kafka.config.log_retention_hours is none) or (kafka.config.log_retention_hours | trim == ''))  
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring maximum size of {{ kafka.service_name }} log segment files
+  - name: KAFKA OVERLAY (BROKER) | configuring maximum size of {{ broker_service_name }} log segment files
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.segment.bytes='
       line: "log.segment.bytes={{ kafka.config.log_segment_bytes }}"
     when: not((kafka.config.log_segment_bytes is undefined) or (kafka.config.log_segment_bytes is none) or (kafka.config.log_segment_bytes | trim == ''))  
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring interval at which {{ kafka.service_name }} log segments are checked
+  - name: KAFKA OVERLAY (BROKER) | configuring interval at which {{ broker_service_name }} log segments are checked
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.retention.check.interval.ms='
       line: "log.retention.check.interval.ms={{ kafka.config.log_retention_check_interval_ms }}"
     when: not((kafka.config.log_retention_check_interval_ms is undefined) or (kafka.config.log_retention_check_interval_ms is none) or (kafka.config.log_retention_check_interval_ms | trim == ''))  
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring zookeeper hosts for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring zookeeper hosts for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^zookeeper.connect='
       line: "zookeeper.connect={{ groups['zookeeper'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
     notify: restart broker
       
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} zookeeper connection timeout
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} zookeeper connection timeout
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^zookeeper.connection.timeout.ms='
       line: "zookeeper.connection.timeout.ms={{ kafka.config.zookeeper_connection_timeout_ms }}"
     when: not((kafka.config.zookeeper_connection_timeout_ms is undefined) or (kafka.config.zookeeper_connection_timeout_ms is none) or (kafka.config.zookeeper_connection_timeout_ms | trim == ''))  
     notify: restart broker
     
-  - name: CONFLUENT OVERLAY (BROKER) | enabling control center metrics for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling control center metrics for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^metric.reporters='
       line: "metric.reporters={{ kafka.config.metric_reporters }}"
       insertafter: '^#metric.reporters='
@@ -195,20 +207,27 @@
       - groups['controlcenter'] | length > 0
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | installing cruise control metrics reporter
+  # these lines set the java path for kafka
+  - set_fact:
+      apache_lib_path: "{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/libs"
+  
+  - set_fact: 
+      java_lib_dir: "{{ (apache_kafka) | ternary(apache_lib_path, '/usr/share/java/kafka') }}"
+      
+  - name: KAFKA OVERLAY (BROKER) | installing cruise control metrics reporter to {{ java_lib_dir }}
     copy:
       src: "{{ key_path }}/cruise-control-metrics-reporter-{{ application_version | default(cruisecontrol.version) }}.jar"
-      dest: /usr/share/java/kafka
-      owner: root
-      group: root
+      dest: "{{ java_lib_dir }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
       mode: 0644
     when:
       - groups['cruisecontrol'] is defined
       - groups['cruisecontrol'] | length > 0
     
-  - name: CONFLUENT OVERLAY (BROKER) | enabling cruise control metrics for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling cruise control metrics for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^metric.reporters='
       line: "metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"
       insertafter: '^#metric.reporters='
@@ -217,9 +236,9 @@
       - groups['cruisecontrol'] | length > 0
     notify: restart broker
     
-  - name: CONFLUENT OVERLAY (BROKER) | enabling and configuring control center metrics bootstrap servers for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling and configuring control center metrics bootstrap servers for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^confluent.metrics.reporter.bootstrap.servers='
       line: "confluent.metrics.reporter.bootstrap.servers={{ groups['kafka_public'] | join(':' + kafka.config.broker_port + ',') }}:{{ kafka.config.broker_port }}"
       insertafter: '^#confluent.metrics.reporter.bootstrap.servers='
@@ -228,9 +247,9 @@
       - groups['controlcenter'] | length > 0
     notify: restart broker
   
-  - name: CONFLUENT OVERLAY (BROKER) | enabling and configuring cruise control metrics bootstrap servers for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling and configuring cruise control metrics bootstrap servers for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^cruise.control.metrics.reporter.bootstrap.servers='
       line: "cruise.control.metrics.reporter.bootstrap.servers={{ groups['kafka_public'] | join(':' + kafka.config.broker_port + ',') }}:{{ kafka.config.broker_port }}"
       insertafter: '^#confluent.metrics.reporter.bootstrap.servers='
@@ -239,9 +258,9 @@
       - groups['cruisecontrol'] | length > 0
     notify: restart broker
     
-  - name: CONFLUENT OVERLAY (BROKER) | enabling and configuring control center metrics for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | enabling and configuring control center metrics for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^confluent.metrics.reporter.topic.replicas='
       line: "confluent.metrics.reporter.topic.replicas={{ kafka.config.confluent_metrics_reporter_topic_replicas }}"
       insertafter: '^#confluent.metrics.reporter.topic.replicas='
@@ -252,191 +271,225 @@
       - kafka.config.confluent_metrics_reporter_topic_replicas > 1
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | setting {{ kafka.service_name }} metrics reporting to {{ kafka.config.confluent_metrics }}
+  - name: KAFKA OVERLAY (BROKER) | setting {{ broker_service_name }} metrics reporting to {{ kafka.config.confluent_metrics }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^confluent.support.metrics.enable='
       line: "confluent.support.metrics.enable={{ kafka.config.confluent_metrics }}"
     notify: restart broker
     
-  - name: CONFLUENT OVERLAY (BROKER) | configuring group rebalance delay for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring group rebalance delay for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^group.initial.rebalance.delay.ms='
       line: "group.initial.rebalance.delay.ms={{ kafka.config.group_initial_rebalance_delay_ms }}"
     when: not((kafka.config.group_initial_rebalance_delay_ms is undefined) or (kafka.config.group_initial_rebalance_delay_ms is none) or (kafka.config.group_initial_rebalance_delay_ms | trim == ''))  
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring background threads for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring background threads for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^background.threads='
       line: "background.threads={{ kafka.config.background_threads }}"
     when: not((kafka.config.background_threads is undefined) or (kafka.config.background_threads is none) or (kafka.config.background_threads | trim == ''))  
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} number of threads that move replicas between log directories
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} number of threads that move replicas between log directories
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^num.replica.alter.log.dirs.threads='
       line: "num.replica.alter.log.dirs.threads={{ kafka.config.num_replica_alter_log_dirs_threads }}"
     when: not((kafka.config.num_replica_alter_log_dirs_threads is undefined) or (kafka.config.num_replica_alter_log_dirs_threads is none) or (kafka.config.num_replica_alter_log_dirs_threads | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring number of threads that move replicas between log directories for {{ kafka.service_name }} 
+  - name: KAFKA OVERLAY (BROKER) | configuring number of threads that move replicas between log directories for {{ broker_service_name }} 
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^num.replica.fetchers='
       line: "num.replica.fetchers={{ kafka.config.num_replica_fetchers }}"
     when: not((kafka.config.num_replica_fetchers is undefined) or (kafka.config.num_replica_fetchers is none) or (kafka.config.num_replica_fetchers | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring number of {{ kafka.service_name }} queued requests allowed before blocking network threads
+  - name: KAFKA OVERLAY (BROKER) | configuring number of {{ broker_service_name }} queued requests allowed before blocking network threads
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^queued.max.requests='
       line: "queued.max.requests={{ kafka.config.queued_max_requests }}"
     when: not((kafka.config.queued_max_requests is undefined) or (kafka.config.queued_max_requests is none) or (kafka.config.queued_max_requests | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring frequency with which the high watermark is saved out to disk for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring frequency with which the high watermark is saved out to disk for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^replica.high.watermark.checkpoint.interval.ms='
       line: "replica.high.watermark.checkpoint.interval.ms={{ kafka.config.replica_high_watermark_checkpoint_interval_ms }}"
     when: not((kafka.config.replica_high_watermark_checkpoint_interval_ms is undefined) or (kafka.config.replica_high_watermark_checkpoint_interval_ms is none) or (kafka.config.replica_high_watermark_checkpoint_interval_ms | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring when the {{ kafka.service_name }} leader will remove the follower from isr
+  - name: KAFKA OVERLAY (BROKER) | configuring when the {{ broker_service_name }} leader will remove the follower from isr
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^replica.lag.time.max.ms='
       line: "replica.lag.time.max.ms={{ kafka.config.replica_lag_time_max_ms }}"
     when: not((kafka.config.replica_lag_time_max_ms is undefined) or (kafka.config.replica_lag_time_max_ms is none) or (kafka.config.replica_lag_time_max_ms | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring socket receive buffer for network requests for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring socket receive buffer for network requests for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^replica.socket.receive.buffer.bytes='
       line: "replica.socket.receive.buffer.bytes={{ kafka.config.replica_socket_receive_buffer_bytes }}"
     when: not((kafka.config.replica_socket_receive_buffer_bytes is undefined) or (kafka.config.replica_socket_receive_buffer_bytes is none) or (kafka.config.replica_socket_receive_buffer_bytes | trim == ''))
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring socket timeout for network requests for {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring socket timeout for network requests for {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^replica.socket.timeout.ms='
       line: "replica.socket.timeout.ms={{ kafka.config.replica_socket_timeout_ms }}"
     when: not((kafka.config.replica_socket_timeout_ms is undefined) or (kafka.config.replica_socket_timeout_ms is none) or (kafka.config.replica_socket_timeout_ms | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring maximum amount of time the {{ kafka.service_name }} client will wait for the request response
+  - name: KAFKA OVERLAY (BROKER) | configuring maximum amount of time the {{ broker_service_name }} client will wait for the request response
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^request.timeout.ms='
       line: "request.timeout.ms={{ kafka.config.request_timeout_ms }}"
     when: not((kafka.config.request_timeout_ms is undefined) or (kafka.config.request_timeout_ms is none) or (kafka.config.request_timeout_ms | trim == ''))
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring maximum allowed timeout for {{ kafka.service_name }} transactions
+  - name: KAFKA OVERLAY (BROKER) | configuring maximum allowed timeout for {{ broker_service_name }} transactions
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^transaction.max.timeout.ms='
       line: "transaction.max.timeout.ms={{ kafka.config.transaction_max_timeout_ms }}"
     when: not((kafka.config.transaction_max_timeout_ms is undefined) or (kafka.config.transaction_max_timeout_ms is none) or (kafka.config.transaction_max_timeout_ms | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | enabling {{ kafka.service_name }} replicas not in the isr set to be elected as leader
+  - name: KAFKA OVERLAY (BROKER) | enabling {{ broker_service_name }} replicas not in the isr set to be elected as leader
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^unclean.leader.election.enable='
       line: "unclean.leader.election.enable={{ kafka.config.unclean_leader_election_enable }}"
     when: not((kafka.config.unclean_leader_election_enable is undefined) or (kafka.config.unclean_leader_election_enable is none) or (kafka.config.unclean_leader_election_enable | trim == ''))
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring socket timeout for {{ kafka.service_name }} controller-to-broker channels
+  - name: KAFKA OVERLAY (BROKER) | configuring socket timeout for {{ broker_service_name }} controller-to-broker channels
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^controller.socket.timeout.ms='
       line: "controller.socket.timeout.ms={{ kafka.config.controller_socket_timeout_ms }}"
     when: not((kafka.config.controller_socket_timeout_ms is undefined) or (kafka.config.controller_socket_timeout_ms is none) or (kafka.config.controller_socket_timeout_ms | trim == ''))
     notify: restart broker
  
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} total memory used for log deduplication
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} total memory used for log deduplication
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.cleaner.dedupe.buffer.size='
       line: "log.cleaner.dedupe.buffer.size={{ kafka.config.log_cleaner_dedupe_buffer_size }}"
     when: not((kafka.config.log_cleaner_dedupe_buffer_size is undefined) or (kafka.config.log_cleaner_dedupe_buffer_size is none) or (kafka.config.log_cleaner_dedupe_buffer_size | trim == ''))
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring {{ kafka.service_name }} total memory used for log cleaner I/O buffers
+  - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} total memory used for log cleaner I/O buffers
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.cleaner.io.buffer.size='
       line: "log.cleaner.io.buffer.size={{ kafka.config.log_cleaner_io_buffer_size }}"
     when: not((kafka.config.log_cleaner_io_buffer_size is undefined) or (kafka.config.log_cleaner_io_buffer_size is none) or (kafka.config.log_cleaner_io_buffer_size | trim == ''))
     notify: restart broker
 
-  - name: CONFLUENT OVERLAY (BROKER) | configuring number of {{ kafka.service_name }} background threads to use for log cleaning
+  - name: KAFKA OVERLAY (BROKER) | configuring number of {{ broker_service_name }} background threads to use for log cleaning
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.cleaner.threads='
       line: "log.cleaner.threads={{ kafka.config.log_cleaner_threads }}"
     when: not((kafka.config.log_cleaner_threads is undefined) or (kafka.config.log_cleaner_threads is none) or (kafka.config.log_cleaner_threads | trim == ''))
     notify: restart broker
   
   # # this seems to be required to avoid connector timestamp warnings
-  - name: CONFLUENT OVERLAY (BROKER) | configuring message timestamp of {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | configuring message timestamp of {{ broker_service_name }}
     lineinfile:
-      path: "{{ kafka.config_file }}"
+      path: "{{ broker_config_file }}"
       regexp: '^log.message.timestamp.type='
       line: "log.message.timestamp.type=LogAppendTime"
     notify: restart broker
- 
-  - name: CONFLUENT OVERLAY (BROKER) | ensuring {{ kafka.user_service }} exists
+     
+  - name: KAFKA OVERLAY (BROKER) | ensuring {{ kafka.user_service }} exists
     file:
       path: "{{ kafka.user_service }}"
       owner: root
       group: root
       state: directory
       mode: 0755
+  
+  - set_fact: 
+      broker_wrapper: "{{ (apache_kafka) | ternary('apache.kafka.j2', 'confluent.kafka.j2') }}"
       
-  - name: CONFLUENT OVERLAY (BROKER) | installing {{ kafka.service_name }} into {{ kafka.user_service }}
+  - name: KAFKA OVERLAY (BROKER) | installing {{ broker_service_name }} into {{ kafka.user_service }}
     template:
-      src: confluent.kafka.j2
-      dest: "{{ kafka.user_service }}/confluent-kafka"
+      src: "{{ broker_wrapper }}"
+      dest: "{{ kafka.user_service }}/broker"
       mode: 0755
-      owner: "{{ kafka.user }}"
-      group: "{{ kafka.group }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
       
   become: yes
   
 - block:
   
-  - name: CONFLUENT OVERLAY (BROKER) | creating systemd override directory
+  - block:
+    
+    - name: KAFKA OVERLAY (BROKER) | ensuring {{ kafka.environment.LOG_DIR }} exists
+      file:
+        path: "{{ kafka.environment.LOG_DIR }}"
+        owner: "{{ broker_user }}"
+        group: "{{ broker_group }}"
+        state: directory
+        mode: 0755
+        
+    - name: KAFKA OVERLAY (BROKER) | installing systemd {{ broker_service_name }} script
+      template:
+        src: apache-kafka.service.j2
+        dest: "/etc/systemd/system/{{ broker_service_name }}.service"
+        mode: 0640
+        owner: "{{ broker_user }}"
+        group: "{{ broker_group }}"
+      notify:
+        - reload systemd
+    
+    - name: KAFKA OVERLAY (BROKER) | enabling {{ broker_service_name }}
+      systemd:
+        name: "{{ broker_service_name }}.service"
+        enabled: yes
+    when:
+      - apache_kafka
+      - not confluent_kafka
+      
+  - set_fact: 
+      broker_override_name: "{{ (apache_kafka) | ternary(kafka.apache.systemd_override, kafka.confluent.systemd_override) }}"
+      
+  - name: KAFKA OVERLAY (BROKER) | creating systemd override directory {{ broker_override_name }}
     file:
-      path: "{{ kafka.systemd_override }}"
-      owner: "{{ kafka.user }}"
-      group: "{{ kafka.group }}"
+      path: "{{ broker_override_name }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
       state: directory
       mode: 0750
  
-  - name: CONFLUENT OVERLAY (BROKER) | installing {{ kafka.service_name }} environment overrride
+  - name: KAFKA OVERLAY (BROKER) | installing {{ broker_service_name }} environment overrride
     template:
       src: environment.j2
-      dest: "{{ kafka.systemd_override }}/override.conf"
+      dest: "{{ broker_override_name }}/override.conf"
       mode: 0640
-      owner: "{{ kafka.user }}"
-      group: "{{ kafka.group }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
     notify:
       - reload systemd
       - restart broker
       
-  - name: CONFLUENT OVERLAY (BROKER) | starting {{ kafka.service_name }}
+  - name: KAFKA OVERLAY (BROKER) | starting {{ broker_service_name }}
     systemd:
-      name: "{{ kafka.service_name }}"
+      name: "{{ broker_service_name }}"
       state: started
     
   become: yes

--- a/roles/kafka/templates/apache-kafka.service.j2
+++ b/roles/kafka/templates/apache-kafka.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Apache Kafka
+Documentation=https://kafka.apache.org
+After=network.target remote-fs.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}
+User={{ broker_user }}
+Group={{ broker_group }}
+ExecStart={{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/kafka-server-start.sh {{ broker_config_file }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/kafka/templates/apache.kafka.j2
+++ b/roles/kafka/templates/apache.kafka.j2
@@ -2,7 +2,7 @@
 
 if [ $# -eq 0 ] || [ "$1" = "-h" ] ; then
 	printf "Usage:\\tbroker [-h]\\thelp\\n"
-	printf "Usage:\\tsudo -H -u {{ broker_user }} {{ kafka.user_service }}/confluent-kafka [ start | stop | restart ]\\n"
+	printf "Usage:\\tsudo -H -u {{ broker_user }} {{ kafka.user_service }}/broker [ start | stop | restart ]\\n"
 	exit 0
 fi
 
@@ -11,16 +11,16 @@ if [ "$1" = "start" ] ; then
   {% for key, value in kafka.environment.items() -%}
   {{ " " ~ key }}="{{ value }}"
   {%- endfor %}
-  /usr/bin/nohup /usr/bin/kafka-server-start {{ broker_config_file }} >> {{ kafka.environment.LOG_DIR }}/server.log 2>&1 &
+  /usr/bin/nohup {{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/kafka-server-start.sh {{ broker_config_file }} >> {{ kafka.environment.LOG_DIR }}/server.log 2>&1 &
 elif [ "$1" = "stop" ] ; then
 	printf "[%s %s] INFO Stopping {{ broker_service_name }}...\\n" `/usr/bin/date +'%Y-%m-%d %H:%M:%S'` | /usr/bin/tee -a {{ kafka.environment.LOG_DIR }}/server.log
-	/usr/bin/kafka-server-stop
+	{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/kafka-server-stop.sh
 elif [ "$1" = "restart" ] ; then
 	printf "[%s %s] INFO Stopping {{ broker_service_name }}...\\n" `/usr/bin/date +'%Y-%m-%d %H:%M:%S'` | /usr/bin/tee -a {{ kafka.environment.LOG_DIR }}/server.log
-	/usr/bin/kafka-server-stop
+	{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/kafka-server-stop.sh
 	printf "[%s %s] INFO Starting {{ broker_service_name }}...\\n" `/usr/bin/date +'%Y-%m-%d %H:%M:%S'` | /usr/bin/tee -a {{ kafka.environment.LOG_DIR }}/server.log
   {% for key, value in kafka.environment.items() -%}
   {{ " " ~ key }}="{{ value }}"
   {%- endfor %}
-  /usr/bin/nohup /usr/bin/kafka-server-start {{ broker_config_file }} >> {{ kafka.environment.LOG_DIR }}/server.log 2>&1 &
+  /usr/bin/nohup {{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/kafka-server-start.sh {{ broker_config_file }} >> {{ kafka.environment.LOG_DIR }}/server.log 2>&1 &
 fi

--- a/roles/ksql/defaults/main.yml
+++ b/roles/ksql/defaults/main.yml
@@ -14,7 +14,7 @@ ksql:
     # JMX_PORT: 10101
   config:
     application.id: ksql-server
-    listener_port: 8088
+    listener_port: '8088'
     logs: /var/log/confluent/ksql
     # referenced in /etc/ksql/log4j-file.properties
     cli_logs: /usr/logs/ksql-cli
@@ -22,11 +22,3 @@ ksql:
     streams: /var/lib/kafka-streams
     ssl.endpoint.identification.algorithm: ""
     confluent_metrics: False
-kafka:
-   config:
-     # if this gets changed it needs to be changed under kafka defaults
-     broker_port: '9092'
-
-
-
-

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -1,7 +1,10 @@
 # (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
 #
 #
---- 
+---
+# this isn't strictly necessary for ksql, but the kafka broker default variables need JVM settings
+- import_tasks: tune.yml
+  
 - import_tasks: interface-facts.yml
 
 - block:

--- a/roles/ksql/tasks/tune.yml
+++ b/roles/ksql/tasks/tune.yml
@@ -1,0 +1,20 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+#
+---  
+# this calculates the available memory minus 768MB for the OS (rounded down) for the JVM
+- name: CONFLUENT OVERLAY (CONTROL CENTER TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
+  set_fact:
+    heap_req="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),(((ansible_memtotal_mb | int - 768) / 1024) | round(0,'floor') | int)) }}"
+
+# control center heap max is either what's available or 6gb minimum in production
+- name: CONFLUENT OVERLAY (CONTROL CENTER TUNING) | setting jvm heap to {{ ((heap_req | int) > 6) | ternary((heap_req),(6)) }}g
+  set_fact: jvm_heap_mem="{{ ((heap_req | int) > 6) | ternary((heap_req),(6)) }}"
+
+- name: CONFLUENT OVERLAY (CONTROL CENTER TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 1048) | round(0,'floor') | int) }}gb total
+  assert:
+    that:
+      - (jvm_heap_mem | int) <= ((ansible_memtotal_mb | int / 1048) | round(0,'floor') | int) 
+    fail_msg: "heap space inadequate: allocate more RAM, decrease requested heap space, or set 'jvm_heap' to 'auto'"
+    success_msg: "system has enough heap space"
+  

--- a/roles/postflight/defaults/main.yml
+++ b/roles/postflight/defaults/main.yml
@@ -1,15 +1,3 @@
 # postflight variables
 postflight:
   utilsDir: /usr/local/bin
-zookeeper:
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it all needs to be changed under kafka defaults
-    port: '2181'
-broker:
-  user: cp-kafka
-  group: confluent
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it needs to be changed under connect defaults
-    port: '9092'

--- a/roles/postflight/tasks/main.yml
+++ b/roles/postflight/tasks/main.yml
@@ -2,5 +2,7 @@
 #
 # tasks that occur post-appplication installation
 ---
+# this isn't strictly necessary for cruise control, but the kafka broker default variables need JVM settings
+- import_tasks: tune.yml
 # install helper utilities
 - import_tasks: utilities.yml

--- a/roles/postflight/tasks/tune.yml
+++ b/roles/postflight/tasks/tune.yml
@@ -1,0 +1,20 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+#
+---
+- name: KAFKA OVERLAY (POSTFLIGHT) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
+  set_fact:
+    heap_req="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int)) }}"    
+
+# this calculates half the total memory (rounded down) for the JVM; for kafka brokers this should max out at 5g
+- name: KAFKA OVERLAY (POSTFLIGHT) | setting jvm heap to {{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}g
+  set_fact: jvm_heap_mem="{{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}"
+
+- name: KAFKA OVERLAY (POSTFLIGHT) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) }}gb total
+  assert:
+    that:
+      - (jvm_heap_mem | int) <= ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) 
+    fail_msg: "heap space inadequate: allocate more RAM, decrease requested heap space, or set 'jvm_heap' to 'auto'"
+    success_msg: "system has enough heap space"
+
+  

--- a/roles/postflight/tasks/utilities.yml
+++ b/roles/postflight/tasks/utilities.yml
@@ -2,37 +2,61 @@
 #
 # install kafka cluster helper utilities
 ---
+- set_fact: 
+    zookeeper_user: "{{ (apache_kafka) | ternary(zookeeper.apache.user, zookeeper.confluent.user) }}"
+
+- set_fact: 
+    broker_user: "{{ (apache_kafka) | ternary(kafka.apache.user, kafka.confluent.user) }}"
+
+- set_fact: 
+     broker_group: "{{ (apache_kafka) | ternary(kafka.apache.group, kafka.confluent.group) }}"
+  
+- set_fact: 
+    broker_service_name: "{{ (apache_kafka) | ternary(kafka.apache.service_name, kafka.confluent.service_name) }}"
+
+- set_fact: 
+    broker_config_file: "{{ (apache_kafka) | ternary(kafka.apache.config_file, kafka.confluent.config_file) }}"
+
+- set_fact:
+    apache_bin: "{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin"
+
+- set_fact: 
+    utils_path: "{{ (apache_kafka) | ternary(apache_bin, '/usr/bin') }}"
+
+- set_fact: 
+    bin_suffix: "{{ (apache_kafka) | ternary('.sh', '') }}"
+
 - block:
 
-  - name: CONFLUENT OVERLAY (POSTFLIGHT) | installing kafka topic list utility
+  - name: KAFKA OVERLAY (POSTFLIGHT) | installing kafka topic list utility
     template:
       src: list-topics.j2
       dest: "{{ utilsDir | default (postflight.utilsDir) }}/list-topics"
       mode: 0755
-      owner: "{{ broker.user }}"
-      group: "{{ broker.group }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
     when:
       - groups['zookeeper'] is defined
       - groups['zookeeper'] | length > 0
       
-  - name: CONFLUENT OVERLAY (POSTFLIGHT) | installing kafka topic describe utility
+  - name: KAFKA OVERLAY (POSTFLIGHT) | installing kafka topic describe utility
     template:
       src: describe-topic.j2
       dest: "{{ utilsDir | default (postflight.utilsDir) }}/describe-topic"
       mode: 0755
-      owner: "{{ broker.user }}"
-      group: "{{ broker.group }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
     when:
       - groups['zookeeper'] is defined
       - groups['zookeeper'] | length > 0
       
-  - name: CONFLUENT OVERLAY (POSTFLIGHT) | installing kafka topic consume utility
+  - name: KAFKA OVERLAY (POSTFLIGHT) | installing kafka topic consume utility
     template:
       src: consume-topic.j2
       dest: "{{ utilsDir | default (postflight.utilsDir) }}/consume-topic"
       mode: 0755
-      owner: "{{ broker.user }}"
-      group: "{{ broker.group }}"
+      owner: "{{ broker_user }}"
+      group: "{{ broker_group }}"
     when:
       - groups['kafka_broker'] is defined
       - groups['kafka_broker'] | length > 0

--- a/roles/postflight/templates/consume-topic.j2
+++ b/roles/postflight/templates/consume-topic.j2
@@ -10,13 +10,13 @@ elif [[ $# -ge 2 && "$1" = "-b" ]] ; then
    BROKER_HOSTS=$2
    shift && shift
 elif [ $# -eq 1 ]; then
-  BROKER_HOSTS={{ groups['kafka_public'] | join(':9092,') }}:{{ broker.config.port }}
+  BROKER_HOSTS={{ groups['kafka_public'] | join(':9092,') }}:{{ kafka.config.broker_port }}
 fi
 
 # we want to verify the topic exists before we consume it
-/usr/local/bin/list-topics | /usr/bin/grep $1 &> /dev/null
+{{ postflight.utilsDir }}/list-topics | /usr/bin/grep $1 &> /dev/null
  if [ $? == 0 ]; then
-   /usr/bin/kafka-console-consumer --bootstrap-server $BROKER_HOSTS --topic $1 --from-beginning
+   {{ utils_path }}/kafka-console-consumer{{ bin_suffix }} --bootstrap-server $BROKER_HOSTS --topic $1 --from-beginning
  else
    printf "$1 topic does not exist!\n"
    exit 1

--- a/roles/postflight/templates/describe-topic.j2
+++ b/roles/postflight/templates/describe-topic.j2
@@ -3,7 +3,7 @@
 
 # no arguments means describe all
 if [ $# -eq 0 ] ; then
-  ZOOKEEPER_HOSTS={{ groups['zookeeper'] | join(':2181,') }}:2181
+  ZOOKEEPER_HOSTS={{ groups['zookeeper'] | join(':2181,') }}:{{ zookeeper.config.port }}
   TOPICS=`/usr/bin/kafka-topics --list --zookeeper $ZOOKEEPER_HOSTS`
 # help
 elif [ "$1" = "-h" ] ; then
@@ -17,10 +17,10 @@ elif [[ $# -ge 2 && "$1" = "-z" ]] ; then
   TOPICS=$@
 # topics as listed
 elif [ $# -ge 1 ] ; then
-	ZOOKEEPER_HOSTS={{ groups['zookeeper'] | join(':2181,') }}:2181
+	ZOOKEEPER_HOSTS={{ groups['zookeeper'] | join(':2181,') }}:{{ zookeeper.config.port }}
   TOPICS=$@
 fi
 
 for topic in $TOPICS; do
-  /usr/bin/kafka-topics --describe --zookeeper $ZOOKEEPER_HOSTS --topic $topic
+  {{ utils_path }}/kafka-topics{{ bin_suffix }} --describe --zookeeper $ZOOKEEPER_HOSTS --topic $topic
 done

--- a/roles/postflight/templates/list-topics.j2
+++ b/roles/postflight/templates/list-topics.j2
@@ -17,4 +17,4 @@ else
 	exit 1
 fi
 
-/usr/bin/kafka-topics --zookeeper $ZOOKEEPER_HOSTS --list
+{{ utils_path }}/kafka-topics{{ bin_suffix }} --zookeeper $ZOOKEEPER_HOSTS --list

--- a/roles/registry/defaults/main.yml
+++ b/roles/registry/defaults/main.yml
@@ -8,20 +8,8 @@ schema:
     systemd_override: /etc/systemd/system/confluent-schema-registry.service.d
     user_service: /usr/local/bin
     config:
-      schema_registry_listener_port: 8081
+      schema_registry_listener_port: '8081'
       kafkastore.topic: _schemas
       kafkastore_ssl_endpoint_identification_algorithm: ""
     environment:
       SCHEMA_REGISTRY_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
-zookeeper:
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it all needs to be changed under zookeeper and kafka defaults
-    port: '2181'
-kafka:
-  config:
-    # this needs to be quoted as a string for concatenation purposes
-    # if this gets changed it all needs to be changed under zookeeper and kafka defaults
-    broker_port: '9092'
-
-

--- a/roles/registry/tasks/main.yml
+++ b/roles/registry/tasks/main.yml
@@ -2,6 +2,9 @@
 #
 # routines for provisioning registry services
 ---
+# this isn't strictly necessary for the registry, but the zookeeper default variables need JVM settings
+- import_tasks: tune.yml
+
 - import_tasks: interface-facts.yml
 
 - block:

--- a/roles/registry/tasks/tune.yml
+++ b/roles/registry/tasks/tune.yml
@@ -1,0 +1,20 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+#
+---
+- name: CONFLUENT OVERLAY (JVM TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
+  set_fact:
+    heap_req="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int)) }}"    
+
+# this calculates half the total memory (rounded down) for the JVM; for kafka brokers this should max out at 5g
+- name: CONFLUENT OVERLAY (JVM TUNING) | setting jvm heap to {{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}g
+  set_fact: jvm_heap_mem="{{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}"
+
+- name: CONFLUENT OVERLAY (JVM TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) }}gb total
+  assert:
+    that:
+      - (jvm_heap_mem | int) <= ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) 
+    fail_msg: "heap space inadequate: allocate more RAM, decrease requested heap space, or set 'jvm_heap' to 'auto'"
+    success_msg: "system has enough heap space"
+
+  

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -1,10 +1,17 @@
 # configuration variables for zookeeper services
 zookeeper:
-  user: cp-kafka
-  group: confluent
-  config_file: /etc/kafka/zookeeper.properties
-  service_name: confluent-zookeeper
-  systemd_override: /etc/systemd/system/confluent-zookeeper.service.d
+  apache:
+    user: kafka
+    group: kafka
+    service_name: apache-zookeeper
+    systemd_override: /etc/systemd/system/apache-zookeeper.service.d
+    config_file: "{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/config/zookeeper.properties"
+  confluent:
+    user: cp-kafka
+    group: confluent
+    service_name: confluent-zookeeper
+    systemd_override: /etc/systemd/system/confluent-zookeeper.service.d
+    config_file: /etc/kafka/zookeeper.properties
   user_service: /usr/local/bin
   config:
     maxClientCnxns: 0
@@ -19,3 +26,4 @@ zookeeper:
     port: '2181'
   environment:
     KAFKA_HEAP_OPTS: "-Xmx{{ jvm_heap_mem }}g -Xms{{ jvm_heap_mem }}g"
+    LOG_DIR: /var/log/kafka

--- a/roles/zookeeper/handlers/main.yml
+++ b/roles/zookeeper/handlers/main.yml
@@ -9,7 +9,7 @@
 - name: restart zookeeper
   listen: "restart zookeeper"
   systemd:
-    name: "{{ zookeeper.service_name }}"
+    name: "{{ zookeeper_service_name }}"
     state: restarted
   become: true
 

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -3,106 +3,117 @@
 # main zookeeper configuration routines
 ---
 - import_tasks: tune.yml
-
 - import_tasks: interface-facts.yml
 
-- block:
+- set_fact: 
+    zookeeper_user: "{{ (apache_kafka) | ternary(zookeeper.apache.user, zookeeper.confluent.user) }}"
+
+- set_fact: 
+    zookeeper_group: "{{ (apache_kafka) | ternary(zookeeper.apache.group, zookeeper.confluent.group) }}"
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | ensuring {{ zookeeper_data_dir | default(zookeeper.config.dataDir) }} exists and have the correct permissions for {{ zookeeper.service_name }}
+- set_fact: 
+    zookeeper_service_name: "{{ (apache_kafka) | ternary(zookeeper.apache.service_name, zookeeper.confluent.service_name) }}"
+
+- set_fact: 
+    zookeeper_config_file: "{{ (apache_kafka) | ternary(zookeeper.apache.config_file, zookeeper.confluent.config_file) }}"
+      
+- block:
+    
+  - name: KAFKA OVERLAY (ZOOKEEPER) | ensuring {{ zookeeper_data_dir | default(zookeeper.config.dataDir) }} exists and has the correct permissions for {{ zookeeper_service_name }}
     file:
       path: "{{ zookeeper_data_dir | default(zookeeper.config.dataDir) }}"
-      owner: "{{ zookeeper.user }}"
-      group: "{{ zookeeper.group }}"
+      owner: "{{ zookeeper_user }}"
+      group: "{{ zookeeper_group }}"
       state: directory
       mode: 0750
     
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} dataDir
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} dataDir
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^dataDir='
       line: "dataDir={{ zookeeper_data_dir | default(zookeeper.config.dataDir) }}"
     notify: restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} on {{ zookeeper_interface_ipv4 }}
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} on {{ zookeeper_interface_ipv4 }}
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^clientPortAddress='
       line: "clientPortAddress={{ zookeeper_interface_ipv4 }}"
     notify: restart zookeeper
     
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} on {{ zookeeper.config.port }}
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} on {{ zookeeper.config.port }}
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^clientPort='
       line: "clientPort={{ zookeeper.config.port }}"
     notify: restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} maxClientCnxns
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} maxClientCnxns
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^maxClientCnxns='
       line: "maxClientCnxns={{ zookeeper.config.maxClientCnxns }}"
     when: not((zookeeper.config.maxClientCnxns is undefined) or (zookeeper.config.maxClientCnxns is none) or (zookeeper.config.maxClientCnxns | trim == ''))
     notify: restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} tickTime
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} tickTime
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^tickTime='
       line: "tickTime={{ zookeeper.config.tickTime }}"
     when: not((zookeeper.config.tickTime is undefined) or (zookeeper.config.tickTime is none) or (zookeeper.config.tickTime | trim == ''))
     notify: restart zookeeper
     
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} initLimit
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} initLimit
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^initLimit='
       line: "initLimit={{ zookeeper.config.initLimit }}"
     when: not((zookeeper.config.initLimit is undefined) or (zookeeper.config.initLimit is none) or (zookeeper.config.initLimit | trim == ''))
     notify: restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} syncLimit
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} syncLimit
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^syncLimit='
       line: "syncLimit={{ zookeeper.config.syncLimit }}"
     when: not((zookeeper.config.syncLimit is undefined) or (zookeeper.config.syncLimit is none) or (zookeeper.config.syncLimit | trim == ''))
     notify: restart zookeeper
     
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} autopurge.snapRetainCount
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} autopurge.snapRetainCount
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^autopurge.snapRetainCount='
       line: "autopurge.snapRetainCount={{ zookeeper.config.autopurge_snapRetainCount }}"
     when: not((zookeeper.config.autopurge_snapRetainCount is undefined) or (zookeeper.config.autopurge_snapRetainCount is none) or (zookeeper.config.autopurge_snapRetainCount | trim == ''))
     notify: restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} autopurge.purgeInterval
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} autopurge.purgeInterval
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: '^autopurge.purgeInterval='
       line: "autopurge.purgeInterval={{ zookeeper.config.autopurge_purgeInterval }}"
     when: not((zookeeper.config.autopurge_purgeInterval is undefined) or (zookeeper.config.autopurge_purgeInterval is none) or (zookeeper.config.autopurge_purgeInterval | trim == ''))
     notify: restart zookeeper
 
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ ansible_play_hosts | length }} {{ zookeeper.service_name }} hosts
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ ansible_play_hosts | length }} {{ zookeeper_service_name }} hosts
     lineinfile:
-      path: "{{ zookeeper.config_file }}"
+      path: "{{ zookeeper_config_file }}"
       regexp: "^server.{{ item.0 + 1 | int }}="
       line: "server.{{ item.0 + 1 | int }}={{ item.1 }}:2888:3888"
     with_indexed_items: "{{ ansible_play_hosts }}"
     notify: restart zookeeper
 
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | configuring {{ zookeeper.service_name }} myid file
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} myid file
     template:
       src: myid.j2
       dest: "{{ zookeeper_data_dir | default(zookeeper.config.dataDir) }}/myid"
       mode: 0644
-      owner: "{{ zookeeper.user }}"
-      group: "{{ zookeeper.group }}"
+      owner: "{{ zookeeper_user }}"
+      group: "{{ zookeeper_group }}"
     notify: restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | ensuring {{ zookeeper.user_service }} exists
+  - name: KAFKA OVERLAY (ZOOKEEPER) | ensuring {{ zookeeper.user_service }} exists
     file:
       path: "{{ zookeeper.user_service }}"
       owner: root
@@ -110,40 +121,75 @@
       state: directory
       mode: 0755
       
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | installing {{ zookeeper.service_name }} into {{ zookeeper.user_service }}
+  - set_fact: 
+      zookeeper_wrapper: "{{ (apache_kafka) | ternary('apache.zookeeper.j2', 'confluent.zookeeper.j2') }}"
+      
+  - name: KAFKA OVERLAY (ZOOKEEPER) | installing {{ zookeeper_service_name }} into {{ zookeeper.user_service }}
     template:
-      src: confluent.zookeeper.j2
-      dest: "{{ zookeeper.user_service }}/confluent-zookeeper"
+      src: "{{ zookeeper_wrapper }}"
+      dest: "{{ zookeeper.user_service }}/zookeeper"
       mode: 0755
-      owner: "{{ zookeeper.user }}"
-      group: "{{ zookeeper.group }}"
+      owner: "{{ zookeeper_user }}"
+      group: "{{ zookeeper_group }}"
       
   become: yes
   
 - block:
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | creating systemd override directory
+  - block:
+    
+    - name: KAFKA OVERLAY (BROKER) | ensuring {{ zookeeper.environment.LOG_DIR }} exists
+      file:
+        path: "{{ zookeeper.environment.LOG_DIR }}"
+        owner: "{{ zookeeper_user }}"
+        group: "{{ zookeeper_group }}"
+        state: directory
+        mode: 0755
+    
+    - name: KAFKA OVERLAY (ZOOKEEPER) | installing systemd {{ zookeeper_service_name }} script
+      template:
+        src: apache-zookeeper.service.j2
+        dest: "/etc/systemd/system/{{ zookeeper_service_name }}.service"
+        mode: 0640
+        owner: "{{ zookeeper_user }}"
+        group: "{{ zookeeper_group }}"
+      notify:
+        - reload systemd
+    
+    - name: KAFKA OVERLAY (ZOOKEEPER) | enabling {{ zookeeper_service_name }}
+      systemd:
+        name: "{{ zookeeper_service_name }}.service"
+        enabled: yes
+        
+    when:
+      - apache_kafka
+      - not confluent_kafka
+  
+  - set_fact: 
+      zookeeper_override_name: "{{ (apache_kafka) | ternary(zookeeper.apache.systemd_override, zookeeper.confluent.systemd_override) }}"
+      
+  - name: KAFKA OVERLAY (ZOOKEEPER) | creating systemd override directory {{ zookeeper_override_name }}
     file:
-      path: "{{ zookeeper.systemd_override }}"
-      owner: "{{ zookeeper.user }}"
-      group: "{{ zookeeper.group }}"
+      path: "{{ zookeeper_override_name }}"
+      owner: "{{ zookeeper_user }}"
+      group: "{{ zookeeper_group }}"
       state: directory
       mode: 0750
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | installing {{ zookeeper.service_name }} environment override
+  - name: KAFKA OVERLAY (ZOOKEEPER) | installing {{ zookeeper_service_name }} environment override
     template:
       src: environment.j2
-      dest: "{{ zookeeper.systemd_override }}/override.conf"
+      dest: "{{ zookeeper_override_name }}/override.conf"
       mode: 0640
-      owner: "{{ zookeeper.user }}"
-      group: "{{ zookeeper.group }}"
+      owner: "{{ zookeeper_user }}"
+      group: "{{ zookeeper_group }}"
     notify:
       - reload systemd
       - restart zookeeper
   
-  - name: CONFLUENT OVERLAY (ZOOKEEPER) | starting {{ zookeeper.service_name }}
+  - name: KAFKA OVERLAY (ZOOKEEPER) | starting {{ zookeeper_service_name }}
     systemd:
-      name: "{{ zookeeper.service_name }}"
+      name: "{{ zookeeper_service_name }}"
       state: started
     
   become: yes

--- a/roles/zookeeper/tasks/tune.yml
+++ b/roles/zookeeper/tasks/tune.yml
@@ -5,7 +5,6 @@
 - name: CONFLUENT OVERLAY (ZOOKEEPER TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
   set_fact:
     jvm_heap_mem="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int)) }}"    
-
 - name: CONFLUENT OVERLAY (ZOOKEEPER TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) }}gb total
   assert:
     that:

--- a/roles/zookeeper/templates/apache-zookeeper.service.j2
+++ b/roles/zookeeper/templates/apache-zookeeper.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Apache Zookeeper
+Documentation=https://zookeeper.apache.org
+After=network.target remote-fs.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}
+User={{ zookeeper_user }}
+Group={{ zookeeper_group }}
+ExecStart={{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/zookeeper-server-start.sh {{ zookeeper_config_file }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/zookeeper/templates/apache.zookeeper.j2
+++ b/roles/zookeeper/templates/apache.zookeeper.j2
@@ -11,16 +11,16 @@ if [ "$1" = "start" ] ; then
   {% for key, value in zookeeper.environment.items() -%}
   {{ " " ~ key }}="{{ value }}"
   {%- endfor %}
-  /usr/bin/nohup /usr/bin/zookeeper-server-start {{ zookeeper_config_file }} >> {{ zookeeper.environment.LOG_DIR }}/server.log 2>&1 &
+  /usr/bin/nohup {{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/zookeeper-server-start.sh {{ zookeeper_config_file }} >> {{ zookeeper.environment.LOG_DIR }}/server.log 2>&1 &
 elif [ "$1" = "stop" ] ; then
 	printf "[%s %s] INFO Stopping {{ zookeeper_service_name }}...\\n" `/usr/bin/date +'%Y-%m-%d %H:%M:%S'` | /usr/bin/tee -a {{ zookeeper.environment.LOG_DIR }}/server.log
-	/usr/bin/zookeeper-server-stop {{ zookeeper_config_file }}
+	{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/zookeeper-server-stop.sh {{ zookeeper_config_file }}
 elif [ "$1" = "restart" ] ; then
 	printf "[%s %s] INFO Stopping {{ zookeeper_service_name }}...\\n" `/usr/bin/date +'%Y-%m-%d %H:%M:%S'` | /usr/bin/tee -a {{ zookeeper.environment.LOG_DIR }}/server.log
-	/usr/bin/zookeeper-server-stop {{ zookeeper_config_file }}
+	{{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/zookeeper-server-stop {{ zookeeper_config_file }}
 	printf "[%s %s] INFO Starting {{ zookeeper_service_name }}...\\n" `/usr/bin/date +'%Y-%m-%d %H:%M:%S'` | /usr/bin/tee -a {{ zookeeper.environment.LOG_DIR }}/server.log
   {% for key, value in zookeeper.environment.items() -%}
   {{ " " ~ key  }}="{{ value }}"
   {%- endfor %}
-  /usr/bin/nohup /usr/bin/zookeeper-server-start {{ zookeeper_config_file }} >> {{ zookeeper.environment.LOG_DIR }}/server.log 2>&1 &
+  /usr/bin/nohup {{ apache.install_dir }}/kafka_{{ packages.scala_version }}-{{ packages.kafka_version }}/bin/zookeeper-server-start {{ zookeeper_config_file }} >> {{ zookeeper.environment.LOG_DIR }}/server.log 2>&1 &
 fi


### PR DESCRIPTION
* add support for apache kafka and zookeeper
* instead of re-defining needed variables in each role, we define them once and include them around. While this is a _better_ solution, its more complex to code as ansible requires every variable, even ones that will never be used, to be defined. This results in more code.