### PR TITLE
support single interface (v1); add application preflight

### DIFF
--- a/deploy
+++ b/deploy
@@ -17,7 +17,7 @@ application=confluent         # application overlay to deploy
 
 # if check is passed in as the last argument run the drift code
 for i in "$@" ; do 
-  [[ $i == "drift" ]] && ./provision-kafka --check --diff --inventory=$1 --tags "$application" -e "tenant_config_path=${2} project=$3 cloud=$4 region=$5 domain=$6 cluster=$7 tenant=${tenant} application=${application} key_path=${8}" | ./check && exit ;
+  [[ $i == "drift" ]] && ./provision-kafka --check --diff --inventory=${1} --tags "$application" -e "tenant_config_path=${2} project=$3 cloud=$4 region=$5 domain=$6 cluster=$7 tenant=${tenant} application=${application} key_path=${8}" | ./check && exit ;
   [[ $i == "replication" ]] && ./provision-replication --inventory=$1 --tags "$application" -e "tenant=$2 project=$3 cloud=$4 region=$5 domain=$6 cluster=$7" && exit ;
 done
 

--- a/provision-kafka
+++ b/provision-kafka
@@ -62,7 +62,6 @@
     - confluent
   vars_files:
     - "{{ tenant_config_path }}/config/os/linux.yml"
-    - "{{ tenant_config_path }}/config/applications/confluent.yml"
   vars:
       # this is semi clever; application gets set based on each host group
       application: "{{ group_names | first }}"
@@ -146,8 +145,9 @@
   hosts: localhost
   gather_facts: no
   tasks:
+    # assumption that the public internal interface is the default
     - name: KAFKA OVERLAY | building kafka public internal host group
-      add_host: hostname="{{ hostvars[item].ansible_eth1.ipv4.address }}" groupname=kafka_public
+      add_host: hostname="{{ hostvars[item].ansible_default_ipv4.address }}" groupname=kafka_public
       with_items: "{{ groups['kafka_broker'] }}"
       when: "'kafka_broker' in groups | default([])"
 
@@ -162,6 +162,7 @@
     - "{{ tenant_config_path }}/config/applications/apache.yml"
     - "{{ tenant_config_path }}/config/applications/confluent.yml"
     - "{{ tenant_config_path }}/config/applications/kafka.yml"
+    - "{{ tenant_config_path }}/config/os/linux.yml"
   tasks:
     - import_role:
         name: kafka
@@ -184,8 +185,9 @@
   hosts: localhost
   gather_facts: no
   tasks:
+    # assumption that the public internal interface is the default
     - name: KAFKA OVERLAY | building kafka ksql public internal host group
-      add_host: hostname="{{ hostvars[item].ansible_eth1.ipv4.address }}" groupname=kafka_ksql_public
+      add_host: hostname="{{ hostvars[item].ansible_default_ipv4.address }}" groupname=kafka_ksql_public
       with_items: "{{ groups['kafka_ksql'] }}"
       when: "'kafka_ksql' in groups | default([])"
 
@@ -195,8 +197,9 @@
   hosts: localhost
   gather_facts: no
   tasks:
+    # assumption that the public internal interface is the default
     - name: KAFKA OVERLAY | retrieving data network ip address
-      add_host: hostname="{{ hostvars[item].ansible_eth1.ipv4.address }}" groupname=kafka_connect_public
+      add_host: hostname="{{ hostvars[item].ansible_default_ipv4.address }}" groupname=kafka_connect_public
       with_items: "{{ groups['kafka_connect'] }}"
       when: "'kafka_connect' in groups | default([])"
 
@@ -232,6 +235,7 @@
     - roles/ksql/defaults/main.yml
     - roles/registry/defaults/main.yml
     - "{{ tenant_config_path }}/config/applications/controlcenter.yml"
+    - "{{ tenant_config_path }}/config/os/linux.yml"
   gather_facts: yes
   tasks:
     - import_role:

--- a/roles/aws/tasks/create-securitygroup.yml
+++ b/roles/aws/tasks/create-securitygroup.yml
@@ -20,8 +20,6 @@
     region: "{{ region }}"
     rules:
       - proto: tcp
-        # from_port: "{{ replicator.distributed.config.listener_port }}" CNK
-        # to_port: "{{ replicator.distributed.config.listener_port }}" CNK
         from_port: 0
         to_port: 65535
         cidr_ip: "{{ external_subnet }}"

--- a/roles/connect/tasks/interface-facts.yml
+++ b/roles/connect/tasks/interface-facts.yml
@@ -1,19 +1,30 @@
 # (c) Copyright 2016 DataNexus Inc.  All Rights Reserved.
 #
 # automatically set facts based on interfaces present
----    
-- name: setting eth0 to all interfaces
-  set_fact:
-    connector_rest_interface: "{{ hostvars[inventory_hostname].ansible_eth0.device }}"
-    connector_rest_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}"
-    connector_rest_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.broadcast }}"
-    connector_rest_metrics_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}"
-  when: hostvars[inventory_hostname].ansible_eth0 is defined
+---
+# this should handle eth or ens prefix with a single or dual interface machine -- is this clever or dangerous
+- set_fact:
+    # set private and public to the same interface by default
+    private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias }}"
+    public_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias }}"
+  when:
+    - hostvars[inventory_hostname].ansible_default_ipv4 is defined
 
-- name: setting eth1 to kafka and metrics
+# this is purely to handle single interface machines; define a new possible nic
+- set_fact:
+    possible_private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[:3] }}{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[-1] | int - 1 }}"
+
+# if the possible nic exists then we adopt it   
+- set_fact:
+    # dual NIC machines have default to public internal
+    private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[:3] }}{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[-1] | int - 1 }}"
+  when:
+    - hostvars[inventory_hostname]['ansible_' + possible_private_internal_interface]['ipv4']['address'] is defined
+
+- name: KAFKA OVERLAY (CONNECT) | setting {{ public_internal_interface }} to all interfaces
   set_fact:
-    connector_rest_interface: "{{ hostvars[inventory_hostname].ansible_eth1.device }}"
-    connector_rest_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth1.ipv4.address }}"
-    connector_rest_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth1.ipv4.broadcast }}"
-    connector_rest_metrics_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth1.ipv4.address }}"    
-  when: hostvars[inventory_hostname].ansible_eth1 is defined
+    connector_rest_interface: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['device'] }}"
+    connector_rest_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['address'] }}"
+    connector_rest_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['broadcast'] }}"
+    connector_rest_metrics_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['address'] }}"
+  when: hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['address'] is defined

--- a/roles/controlcenter/defaults/main.yml
+++ b/roles/controlcenter/defaults/main.yml
@@ -1,6 +1,15 @@
 # configuration variables for confluent control center services
 control:
   center:
+    linux:
+      limits:
+        config_file: /etc/security/limits.conf
+        soft:
+          config:
+            nofile: 16384
+        hard:
+          config:
+            nofile: 16384
     user: cp-control-center
     group: confluent
     config_file: /etc/confluent-control-center/control-center-production.properties

--- a/roles/controlcenter/tasks/main.yml
+++ b/roles/controlcenter/tasks/main.yml
@@ -3,6 +3,8 @@
 # configure confluent controlcenter
 ---
 - import_tasks: tune.yml
+# this is a application specific preflight run after the platform preflight
+- import_tasks: preflight.yml
 
 - block:
   
@@ -70,7 +72,9 @@
       regexp: '^confluent.controlcenter.ksql.url='
       line: "confluent.controlcenter.ksql.url=http://{{ groups['kafka_ksql_public'] | join(':' + ksql.config.listener_port + ',http://') }}:{{ ksql.config.listener_port }}"
       insertafter: '^#confluent.controlcenter.ksql.url='
-    when: groups['kafka_ksql'] | length > 0
+    when: 
+      - groups['kafka_ksql'] is defined
+      - groups['kafka_ksql'] | length > 0
     notify: restart controlcenter
   
   - name: CONFLUENT OVERLAY (CONTROL CENTER) | configuring schema registry hosts
@@ -79,7 +83,9 @@
       regexp: '^confluent.controlcenter.schema.registry.url='
       line: "confluent.controlcenter.schema.registry.url=http://{{ groups['registry'] | join(':' + schema.registry.config.schema_registry_listener_port + ',http://') }}:{{ schema.registry.config.schema_registry_listener_port }}"
       insertafter: '^#confluent.controlcenter.schema.registry.url='
-    when: groups['registry'] | length > 0
+    when:
+      -  groups['registry'] is defined
+      -  groups['registry'] | length > 0
     notify: restart controlcenter
   
   - name: CONFLUENT OVERLAY (CONTROL CENTER) | ensuring {{ control.center.user_service }} exists

--- a/roles/controlcenter/tasks/preflight.yml
+++ b/roles/controlcenter/tasks/preflight.yml
@@ -1,0 +1,42 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+# confluent control center preflight
+---
+- block:
+  
+  - set_fact:
+      dn_soft_nofile: "{{ limits.soft.config.nofile }}"
+    when: limits.soft.config.nofile
+  
+  - set_fact:
+      dn_soft_nofile: "{{ control.center.linux.limits.soft.config.nofile }}"
+    when:
+      - dn_soft_nofile is undefined
+      - control.center.linux.limits.soft.config.nofile
+    
+  - name: CONFLUENT OVERLAY (CONTROL CENTER SHELL LIMITS) | configuring max number of open files (soft)
+    lineinfile:
+      path: "{{ control.center.linux.limits.config_file }}"
+      regexp: '^\* soft nofile'
+      line: "* soft nofile {{ dn_soft_nofile }}"
+    when: dn_soft_nofile is defined
+  
+  - set_fact:
+      dn_hard_nofile: "{{ limits.hard.config.nofile }}"
+    when: limits.hard.config.nofile
+  
+  - set_fact:
+      dn_hard_nofile: "{{ control.center.linux.limits.hard.config.nofile }}"
+    when:
+      - dn_hard_nofile is undefined
+      - control.center.linux.limits.hard.config.nofile
+  
+  - name: CONFLUENT OVERLAY (CONTROL CENTER SHELL LIMITS) | configuring max number of open files (hard)
+    lineinfile:
+      path: "{{ control.center.linux.limits.config_file }}"
+      regexp: '^\* hard nofile'
+      line: "* hard nofile {{ dn_hard_nofile }}"
+    when: dn_hard_nofile is defined
+
+  become: yes
+  

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,5 +1,14 @@
 # configuration variables for kafka broker services
 kafka:
+  linux:
+    limits:
+      config_file: /etc/security/limits.conf
+      soft:
+        config:
+          nofile: 32768
+      hard:
+        config:
+          nofile: 32768
   apache:
     user: kafka
     group: kafka

--- a/roles/kafka/tasks/interface-facts.yml
+++ b/roles/kafka/tasks/interface-facts.yml
@@ -1,19 +1,30 @@
 # (c) Copyright 2016 DataNexus Inc.  All Rights Reserved.
 #
 # automatically set facts based on interfaces present
----    
-- name: setting eth0 to all interfaces
-  set_fact:
-    kafka_interface: "{{ hostvars[inventory_hostname].ansible_eth0.device }}"
-    kafka_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}"
-    kafka_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.broadcast }}"
-    kafka_metrics_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}"
-  when: hostvars[inventory_hostname].ansible_eth0 is defined
+---
+# this should handle eth or ens prefix with a single or dual interface machine -- is this clever or dangerous
+- set_fact:
+    # set private and public to the same interface by default
+    private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias }}"
+    public_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias }}"
+  when:
+    - hostvars[inventory_hostname].ansible_default_ipv4 is defined
 
-- name: setting eth1 to kafka and metrics
+# this is purely to handle single interface machines; define a new possible nic
+- set_fact:
+    possible_private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[:3] }}{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[-1] | int - 1 }}"
+
+# if the possible nic exists then we adopt it   
+- set_fact:
+    # dual NIC machines have default to public internal
+    private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[:3] }}{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[-1] | int - 1 }}"
+  when:
+    - hostvars[inventory_hostname]['ansible_' + possible_private_internal_interface]['ipv4']['address'] is defined
+
+- name: KAFKA OVERLAY (BROKER) | setting {{ public_internal_interface }} to all interfaces
   set_fact:
-    kafka_interface: "{{ hostvars[inventory_hostname].ansible_eth1.device }}"
-    kafka_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth1.ipv4.address }}"
-    kafka_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth1.ipv4.broadcast }}"
-    kafka_metrics_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth1.ipv4.address }}"    
-  when: hostvars[inventory_hostname].ansible_eth1 is defined
+    kafka_interface: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['device'] }}"
+    kafka_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['address'] }}"
+    kafka_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['broadcast'] }}"
+    kafka_metrics_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['address'] }}"
+  when: hostvars[inventory_hostname]['ansible_' + public_internal_interface]['ipv4']['address'] is defined

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -4,6 +4,9 @@
 ---
 - import_tasks: tune.yml
 
+# this is a application specific preflight run after the platform preflight
+- import_tasks: preflight.yml
+
 - import_tasks: interface-facts.yml
 
 - set_fact: 
@@ -17,7 +20,7 @@
 
 - set_fact: 
     broker_config_file: "{{ (apache_kafka) | ternary(kafka.apache.config_file, kafka.confluent.config_file) }}"
-      
+
 - block:
 
   - name: KAFKA OVERLAY (BROKER) | enabling topic deletion for {{ broker_service_name }}

--- a/roles/kafka/tasks/preflight.yml
+++ b/roles/kafka/tasks/preflight.yml
@@ -1,0 +1,42 @@
+# (c) Copyright 2018 DataNexus Inc.  All Rights Reserved.
+#
+# kafka broker preflight
+---
+- block:
+    
+  - set_fact:
+      dn_soft_nofile: "{{ limits.soft.config.nofile }}"
+    when: limits.soft.config.nofile
+  
+  - set_fact:
+      dn_soft_nofile: "{{ kafka.linux.limits.soft.config.nofile }}"
+    when:
+      - dn_slow_start is undefined
+      - kafka.linux.limits.soft.config.nofile
+    
+  - name: KAFKA OVERLAY (SHELL LIMITS) | configuring max number of open files (soft)
+    lineinfile:
+      path: "{{ kafka.linux.limits.config_file }}"
+      regexp: '^\* soft nofile'
+      line: "* soft nofile {{  dn_soft_nofile }}"
+    when: dn_soft_nofile is defined
+  
+  - set_fact:
+      dn_hard_nofile: "{{ limits.hard.config.nofile }}"
+    when: limits.hard.config.nofile
+  
+  - set_fact:
+      dn_hard_nofile: "{{ kafka.linux.limits.hard.config.nofile }}"
+    when:
+      - dn_hard_nofile is undefined
+      - kafka.linux.limits.hard.config.nofile
+      
+  - name: KAFKA OVERLAY (SHELL LIMITS) | configuring max number of open files (hard)
+    lineinfile:
+      path: "{{ kafka.linux.limits.config_file }}"
+      regexp: '^\* hard nofile'
+      line: "* hard nofile {{ dn_hard_nofile }}"
+    when: dn_hard_nofile is defined
+  
+  become: yes
+  

--- a/roles/kafka/tasks/tune.yml
+++ b/roles/kafka/tasks/tune.yml
@@ -2,15 +2,15 @@
 #
 #
 ---
-- name: CONFLUENT OVERLAY (BROKER TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
+- name: KAFKA OVERLAY (BROKER TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
   set_fact:
     heap_req="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int)) }}"    
 
 # this calculates half the total memory (rounded down) for the JVM; for kafka brokers this should max out at 5g
-- name: CONFLUENT OVERLAY (BROKER TUNING) | setting jvm heap to {{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}g
+- name: KAFKA OVERLAY (BROKER TUNING) | setting jvm heap to {{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}g
   set_fact: jvm_heap_mem="{{ ((heap_req | int) <= 5) | ternary((heap_req),(5)) }}"
 
-- name: CONFLUENT OVERLAY (BROKER TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) }}gb total
+- name: KAFKA OVERLAY (BROKER TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) }}gb total
   assert:
     that:
       - (jvm_heap_mem | int) <= ((ansible_memtotal_mb | int / 2048) | round(0,'floor') | int) 

--- a/roles/ksql/tasks/tune.yml
+++ b/roles/ksql/tasks/tune.yml
@@ -3,15 +3,15 @@
 #
 ---  
 # this calculates the available memory minus 768MB for the OS (rounded down) for the JVM
-- name: CONFLUENT OVERLAY (CONTROL CENTER TUNING) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
+- name: CONFLUENT OVERLAY (KSQL) | jvm heap size is...{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),('automatic')) }}
   set_fact:
     heap_req="{{ ((jvm_heap | default('auto')) | int != 0) | ternary ((jvm_heap),(((ansible_memtotal_mb | int - 768) / 1024) | round(0,'floor') | int)) }}"
 
 # control center heap max is either what's available or 6gb minimum in production
-- name: CONFLUENT OVERLAY (CONTROL CENTER TUNING) | setting jvm heap to {{ ((heap_req | int) > 6) | ternary((heap_req),(6)) }}g
+- name: CONFLUENT OVERLAY (KSQL) | setting jvm heap to {{ ((heap_req | int) > 6) | ternary((heap_req),(6)) }}g
   set_fact: jvm_heap_mem="{{ ((heap_req | int) > 6) | ternary((heap_req),(6)) }}"
 
-- name: CONFLUENT OVERLAY (CONTROL CENTER TUNING) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 1048) | round(0,'floor') | int) }}gb total
+- name: CONFLUENT OVERLAY (KSQL) | validating {{ jvm_heap_mem }}gb needed <= {{ ((ansible_memtotal_mb | int / 1048) | round(0,'floor') | int) }}gb total
   assert:
     that:
       - (jvm_heap_mem | int) <= ((ansible_memtotal_mb | int / 1048) | round(0,'floor') | int) 

--- a/roles/preflight/defaults/main.yml
+++ b/roles/preflight/defaults/main.yml
@@ -6,7 +6,7 @@ linux:
       config:
         fsize: unlimited
         # default 1024; control center requires higher
-        nofile: 16384
+        nofile:
         nproc:
         core:
         stack:
@@ -14,7 +14,7 @@ linux:
       config:
         fsize:
         # default 4096; control center requires higher
-        nofile: 16384
+        nofile:
         nproc:
         core:
         stack:

--- a/roles/preflight/tasks/kernel.yml
+++ b/roles/preflight/tasks/kernel.yml
@@ -4,68 +4,158 @@
 ---
 - block:
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring maximum number of file handles
+  - set_fact:
+      dn_file_max: "{{ kernel.config.fs_file_max }}"
+    when: kernel.config.fs_file_max
+  
+  - set_fact:
+      dn_file_max: "{{ linux.kernel.config.fs_file_max }}"
+    when:
+      - dn_file_max is undefined
+      - linux.kernel.config.fs_file_max
+    
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring maximum number of file handles
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: fs.file-max
-      value: "{{ kernel.config.fs_file_max | default(linux.kernel.config.fs_file_max) }}"      
-    when: not((kernel.config.fs_file_max is undefined) or (kernel.config.fs_file_max is none) or (kernel.config.fs_file_max | trim == '')) or not((linux.kernel.config.fs_file_max is undefined) or (linux.kernel.config.fs_file_max is none) or (linux.kernel.config.fs_file_max | trim == ''))
-    
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring core dump pattern
+      value: "{{ dn_file_max }}"      
+    when: dn_file_max is defined
+  
+  - set_fact:
+      dn_core_pattern: "{{ kernel.config.core_pattern }}"
+    when: kernel.config.core_pattern
+  
+  - set_fact:
+      dn_core_pattern: "{{ linux.kernel.config.core_pattern }}"
+    when:
+      - dn_core_pattern is undefined
+      - linux.kernel.config.core_pattern
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring core dump pattern
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.core_pattern
-      value: "{{ kernel.config.core_pattern | default(linux.kernel.config.core_pattern) }}"
-    when: not((kernel.config.core_pattern is undefined) or (kernel.config.core_pattern is none) or (kernel.config.core_pattern | trim == '')) or not((linux.kernel.config.core_pattern is undefined) or (linux.kernel.config.core_pattern is none) or (linux.kernel.config.core_pattern | trim == ''))
+      value: "{{ dn_core_pattern }}"
+    when: dn_core_pattern is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring maximum number of message queue identifiers
+  - set_fact:
+      dn_msgmni: "{{ kernel.config.msgmni }}"
+    when: kernel.config.msgmni
+  
+  - set_fact:
+      dn_msgmni: "{{ linux.kernel.config.msgmni }}"
+    when:
+      - dn_msgmni is undefined
+      - linux.kernel.config.msgmni
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring maximum number of message queue identifiers
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.msgmni
-      value: "{{ kernel.config.msgmni | default(linux.kernel.config.msgmni) }}"
-    when: not((kernel.config.msgmni is undefined) or (kernel.config.msgmni is none) or (kernel.config.msgmni | trim == '')) or not((linux.kernel.config.msgmni is undefined) or (linux.kernel.config.msgmni is none) or (linux.kernel.config.msgmni | trim == ''))
+      value: "{{ dn_msgmni }}"
+    when: dn_msgmni is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring maximum pid value
+  - set_fact:
+      dn_pid_max: "{{ kernel.config.pid_max }}"
+    when: kernel.config.pid_max
+  
+  - set_fact:
+      dn_pid_max: "{{ linux.kernel.config.pid_max }}"
+    when:
+      - dn_pid_max is undefined
+      - linux.kernel.config.pid_max
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring maximum pid value
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.pid_max
-      value: "{{ kernel.config.pid_max | default(linux.kernel.config.pid_max) }}"
-    when: not((kernel.config.pid_max is undefined) or (kernel.config.pid_max is none) or (kernel.config.pid_max | trim == '')) or not((linux.kernel.config.pid_max is undefined) or (linux.kernel.config.pid_max is none) or (linux.kernel.config.pid_max | trim == ''))
+      value: "{{ dn_pid_max }}"
+    when: dn_pid_max is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring semaphore parameters
+  - set_fact:
+      dn_sem: "{{ kernel.config.sem }}"
+    when: kernel.config.sem
+  
+  - set_fact:
+      dn_sem: "{{ linux.kernel.config.sem }}"
+    when:
+      - dn_sem is undefined
+      - linux.kernel.config.sem
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring semaphore parameters
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.sem
-      value: "{{ kernel.config.sem | default(linux.kernel.config.sem) }}"
-    when: not((kernel.config.sem is undefined) or (kernel.config.sem is none) or (kernel.config.sem | trim == '')) or not((linux.kernel.config.sem is undefined) or (linux.kernel.config.sem is none) or (linux.kernel.config.sem | trim == ''))
+      value: "{{ dn_sem }}"
+    when: dn_sem is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring system wide maximum shared memory pages
+  - set_fact:
+      dn_shmall: "{{ kernel.config.shmall }}"
+    when: kernel.config.shmall
+  
+  - set_fact:
+      dn_shmall: "{{ linux.kernel.config.shmall }}"
+    when:
+      - dn_shmall is undefined
+      - linux.kernel.config.shmall
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring system wide maximum shared memory pages
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.shmall
-      value: "{{ kernel.config.shmall | default(linux.kernel.config.shmall) }}"
-    when: not((kernel.config.shall is undefined) or (kernel.config.shall is none) or (kernel.config.shall | trim == '')) or not((linux.kernel.config.shall is undefined) or (linux.kernel.config.shall is none) or (linux.kernel.config.shall | trim == ''))
+      value: "{{ dn_shmall }}"
+    when: dn_shmall is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring system wide maximum shared memory segments
+  - set_fact:
+      dn_shmmni: "{{ kernel.config.shmmni }}"
+    when: kernel.config.shmmni
+  
+  - set_fact:
+      dn_shmmni: "{{ linux.kernel.config.shmmni }}"
+    when:
+      - dn_shmmni is undefined
+      - linux.kernel.config.shmmni
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring system wide maximum shared memory segments
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.shmmni
-      value: "{{ kernel.config.shmmni | default(linux.kernel.config.shmmni) }}"
-    when: not((kernel.config.shmmni is undefined) or (kernel.config.shmmni is none) or (kernel.config.shmmni | trim == '')) or not((linux.kernel.config.shmmni is undefined) or (linux.kernel.config.shmmni is none) or (linux.kernel.config.shmmni | trim == ''))
+      value: "{{ dn_shmmni }}"
+    when: dn_shmmni is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring how often TCP sends out keepalive messages
+  - set_fact:
+      dn_keepalive_time: "{{ kernel.config.tcp_keepalive_time }}"
+    when: kernel.config.tcp_keepalive_time
+  
+  - set_fact:
+      dn_keepalive_time: "{{ linux.kernel.config.tcp_keepalive_time }}"
+    when:
+      - dn_keepalive_time is undefined
+      - linux.kernel.config.tcp_keepalive_time
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring how often TCP sends out keepalive messages
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.net.ipv4.tcp_keepalive_time
-      value: "{{ kernel.config.tcp_keepalive_time | default(linux.kernel.config.tcp_keepalive_time) }}"
-    when: not((kernel.config.tcp_keepalive_time is undefined) or (kernel.config.tcp_keepalive_time is none) or (kernel.config.tcp_keepalive_time | trim == '')) or not((linux.kernel.config.tcp_keepalive_time is undefined) or (linux.kernel.config.tcp_keepalive_time is none) or (linux.kernel.config.tcp_keepalive_time | trim == ''))
+      value: "{{ dn_keepalive_time }}"
+    when: dn_keepalive_time is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT KERNEL) | configuring RFC286 behavior and time out the congestion window
+  - set_fact:
+      dn_slow_start: "{{ kernel.config.tcp_slow_start_after_idle }}"
+    when: kernel.config.tcp_slow_start_after_idle
+  
+  - set_fact:
+      dn_slow_start: "{{ linux.kernel.config.tcp_slow_start_after_idle }}"
+    when:
+      - dn_slow_start is undefined
+      - linux.kernel.config.tcp_slow_start_after_idle
+      
+  - name: KAFKA OVERLAY (PREFLIGHT KERNEL) | configuring RFC286 behavior and time out the congestion window
     sysctl:
       sysctl_file: "{{ linux.kernel.config_file }}"
       name: kernel.net.ipv4.tcp_slow_start_after_idle
-      value: "{{ kernel.config.tcp_slow_start_after_idle | default(linux.kernel.config.tcp_slow_start_after_idle) }}"
-    when: not((kernel.config.tcp_slow_start_after_idle is undefined) or (kernel.config.tcp_slow_start_after_idle is none) or (kernel.config.tcp_slow_start_after_idle | trim == '')) or not((linux.kernel.config.tcp_slow_start_after_idle is undefined) or (linux.kernel.config.tcp_slow_start_after_idle is none) or (linux.kernel.config.tcp_slow_start_after_idle | trim == ''))
+      value: "{{ dn_slow_start }}"
+    when: dn_slow_start is defined
   
   become: yes
   when:

--- a/roles/preflight/tasks/limits.yml
+++ b/roles/preflight/tasks/limits.yml
@@ -3,76 +3,176 @@
 # OS tasks to set shell limits - these take effect at each shell login
 ---
 - block:
+    
+  - set_fact:
+      dn_soft_fsize: "{{ limits.soft.config.fsize }}"
+    when: limits.soft.config.fsize
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring maximum filesize (soft)
+  - set_fact:
+      dn_soft_fsize: "{{ linux.limits.soft.config.fsize }}"
+    when:
+      - dn_soft_fsize is undefined
+      - linux.limits.soft.config.fsize
+  
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring maximum filesize (soft)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* soft fsize'
-      line: "* soft fsize {{ limits.soft.fsize | default(linux.limits.soft.config.fsize) }}"
-    when: not((limits.soft.config.fsize is undefined) or (limits.soft.config.fsize is none) or (limits.soft.config.fsize | trim == '')) or not((linux.limits.soft.config.fsize is undefined) or (linux.limits.soft.config.fsize is none) or (linux.limits.soft.config.fsize | trim == ''))
+      line: "* soft fsize {{ dn_soft_fsize }}"
+    when: dn_soft_fsize is defined
+  
+  - set_fact:
+      dn_hard_fsize: "{{ limits.hard.config.fsize }}"
+    when: limits.hard.config.fsize
+  
+  - set_fact:
+      dn_hard_fsize: "{{ linux.limits.hard.config.fsize }}"
+    when:
+      - dn_hard_fsize is undefined
+      - linux.limits.hard.config.fsize
       
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring maximum filesize (hard)
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring maximum filesize (hard)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* hard fsize'
-      line: "* hard fsize {{ limits.hard.fsize | default(linux.limits.hard.config.fsize) }}"
-    when: not((limits.hard.config.fsize is undefined) or (limits.hard.config.fsize is none) or (limits.hard.config.fsize | trim == '')) or not((linux.limits.hard.config.fsize is undefined) or (linux.limits.hard.config.fsize is none) or (linux.limits.hard.config.fsize | trim == ''))
+      line: "* hard fsize {{ dn_hard_fsize }}"
+    when: dn_hard_fsize is defined
+
+  - set_fact:
+      dn_soft_nofile: "{{ limits.soft.config.nofile }}"
+    when: limits.soft.config.nofile
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring max number of open files (soft)
+  - set_fact:
+      dn_soft_nofile: "{{ linux.limits.soft.config.nofile }}"
+    when:
+      - dn_soft_nofile is undefined
+      - linux.limits.soft.config.nofile
+  
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring max number of open files (soft)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* soft nofile'
-      line: "* soft nofile {{ limits.soft.nofile | default(linux.limits.soft.config.nofile) }}"
-    when: not((limits.soft.config.nofile is undefined) or (limits.soft.config.nofile is none) or (limits.soft.config.nofile | trim == '')) or not((linux.limits.soft.config.nofile is undefined) or (linux.limits.soft.config.nofile is none) or (linux.limits.soft.config.nofile | trim == ''))
+      line: "* soft nofile {{ dn_soft_nofile }}"
+    when: dn_soft_nofile is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring max number of open files (hard)
+  - set_fact:
+      dn_hard_nofile: "{{ limits.hard.config.nofile }}"
+    when: limits.hard.config.nofile
+  
+  - set_fact:
+      dn_hard_nofile: "{{ linux.limits.hard.config.nofile }}"
+    when:
+      - dn_hard_nofile is undefined
+      - linux.limits.hard.config.nofile
+      
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring max number of open files (hard)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* hard nofile'
-      line: "* hard nofile {{ limits.hard.nofile | default(linux.limits.hard.config.nofile) }}"
-    when: not((limits.hard.config.nofile is undefined) or (limits.hard.config.nofile is none) or (limits.hard.config.nofile | trim == '')) or not((linux.limits.hard.config.nofile is undefined) or (linux.limits.hard.config.nofile is none) or (linux.limits.hard.config.nofile | trim == ''))
+      line: "* hard nofile {{ dn_hard_nofile }}"
+    when: dn_hard_nofile is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring max number of processes (soft)
+  - set_fact:
+      dn_soft_nproc: "{{ limits.soft.config.nproc }}"
+    when: limits.soft.config.nproc
+  
+  - set_fact:
+      dn_soft_nproc: "{{ linux.limits.soft.config.nproc }}"
+    when:
+      - dn_soft_nproc is undefined
+      - linux.limits.soft.config.nproc
+  
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring max number of processes (soft)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* soft nproc'
-      line: "* soft nproc {{ limits.soft.nproc | default(linux.limits.soft.config.nproc) }}"
-    when: not((limits.soft.config.nproc is undefined) or (limits.soft.config.nproc is none) or (limits.soft.config.nproc | trim == '')) or not((linux.limits.soft.config.nproc is undefined) or (linux.limits.soft.config.nproc is none) or (linux.limits.soft.config.nproc | trim == ''))
+      line: "* soft nproc {{ dn_soft_nproc }}"
+    when: dn_soft_nproc is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring max number of processes (hard)
+  - set_fact:
+      dn_hard_nproc: "{{ limits.hard.config.nproc }}"
+    when: limits.hard.config.nproc
+  
+  - set_fact:
+      dn_hard_nproc: "{{ linux.limits.hard.config.nproc }}"
+    when:
+      - dn_hard_nproc is undefined
+      - linux.limits.hard.config.nproc
+      
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring max number of processes (hard)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* hard nproc'
-      line: "* hard nproc {{ limits.hard.nproc | default(linux.limits.hard.config.nproc) }}"
-    when: not((limits.hard.config.nproc is undefined) or (limits.hard.config.nproc is none) or (limits.hard.config.nproc | trim == '')) or not((linux.limits.hard.config.nproc is undefined) or (linux.limits.hard.config.nproc is none) or (linux.limits.hard.config.nproc | trim == ''))
+      line: "* hard nproc {{ dn_hard_nproc }}"
+    when: dn_hard_nproc is defined
 
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring the core file size limit (soft)
+  - set_fact:
+      dn_soft_core: "{{ limits.soft.config.core }}"
+    when: limits.soft.config.core
+  
+  - set_fact:
+      dn_soft_core: "{{ linux.limits.soft.config.core }}"
+    when:
+      - dn_soft_core is undefined
+      - linux.limits.soft.config.core
+      
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring the core file size limit (soft)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* soft core'
-      line: "* soft core {{ limits.soft.core | default(linux.limits.soft.config.core) }}"
-    when: not((limits.soft.config.core is undefined) or (limits.soft.config.core is none) or (limits.soft.config.core | trim == '')) or not((linux.limits.soft.config.core is undefined) or (linux.limits.soft.config.core is none) or (linux.limits.soft.config.core | trim == ''))
+      line: "* soft core {{ dn_soft_core }}"
+    when: dn_soft_core is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring the core file size limit (hard)
+  - set_fact:
+      dn_hard_core: "{{ limits.hard.config.core }}"
+    when: limits.hard.config.core
+  
+  - set_fact:
+      dn_hard_core: "{{ linux.limits.hard.config.core }}"
+    when:
+      - dn_hard_core is undefined
+      - linux.limits.hard.config.core
+      
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring the core file size limit (hard)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* hard core'
-      line: "* hard core {{ limits.hard.core | default(linux.limits.hard.config.core) }}"
-    when: not((limits.hard.config.core is undefined) or (limits.hard.config.core is none) or (limits.hard.config.core | trim == '')) or not((linux.limits.hard.config.core is undefined) or (linux.limits.hard.config.core is none) or (linux.limits.hard.config.core | trim == ''))
+      line: "* hard core {{ dn_hard_core }}"
+    when: dn_hard_core is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring the max stack size (soft)
+  - set_fact:
+      dn_soft_stack: "{{ limits.soft.config.stack }}"
+    when: limits.soft.config.stack
+  
+  - set_fact:
+      dn_soft_stack: "{{ linux.limits.soft.config.stack }}"
+    when:
+      - dn_soft_stack is undefined
+      - linux.limits.soft.config.stack
+      
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring the max stack size (soft)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* soft stack'
-      line: "* soft stack {{ limits.soft.stack | default(linux.limits.soft.config.stack) }}"
-    when: not((limits.soft.config.stack is undefined) or (limits.soft.config.stack is none) or (limits.soft.config.stack | trim == '')) or not((linux.limits.soft.config.stack is undefined) or (linux.limits.soft.config.stack is none) or (linux.limits.soft.config.stack | trim == ''))
+      line: "* soft stack {{ dn_soft_stack }}"
+    when: dn_soft_stack is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT LIMITS) | configuring the max stack size (hard)
+  - set_fact:
+      dn_hard_stack: "{{ limits.hard.config.stack }}"
+    when: limits.hard.config.stack
+  
+  - set_fact:
+      dn_hard_stack: "{{ linux.limits.hard.config.stack }}"
+    when:
+      - dn_hard_stack is undefined
+      - linux.limits.hard.config.stack
+      
+  - name: KAFKA OVERLAY (PREFLIGHT LIMITS) | configuring the max stack size (hard)
     lineinfile:
       path: "{{ linux.limits.config_file }}"
       regexp: '^\* hard stack'
-      line: "* hard stack {{ limits.hard.stack | default(linux.limits.hard.config.stack) }}"
-    when: not((limits.hard.config.stack is undefined) or (limits.hard.config.stack is none) or (limits.hard.config.stack | trim == '')) or not((linux.limits.hard.config.stack is undefined) or (linux.limits.hard.config.stack is none) or (linux.limits.hard.config.stack | trim == ''))
+      line: "* hard stack {{ dn_hard_stack }}"
+    when: dn_hard_stack is defined
 
   become: yes
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'

--- a/roles/preflight/tasks/vm.yml
+++ b/roles/preflight/tasks/vm.yml
@@ -4,34 +4,74 @@
 ---
 - block:
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring percentage of available memory that contains free and reclaimable pages
+  - set_fact:
+      dn_dirty_ratio: "{{ vm.config.dirty_ratio }}"
+    when: vm.config.dirty_ratio
+  
+  - set_fact:
+      dn_dirty_ratio: "{{ linux.vm.config.dirty_ratio }}"
+    when:
+      - dn_dirty_ratio is undefined
+      - linux.vm.config.dirty_ratio
+    
+  - name: KAFKA OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring percentage of available memory that contains free and reclaimable pages
     sysctl:
       sysctl_file: "{{ linux.vm.config_file }}"
       name: vm.dirty_ratio
-      value: "{{ vm.config.dirty_ratio | default(linux.vm.config.dirty_ratio) }}"
-    when: not((vm.config.dirty_ratio is undefined) or (vm.config.dirty_ratio is none) or (vm.config.dirty_ratio | trim == '')) or not((linux.vm.config.dirty_ratio is undefined) or (linux.vm.config.dirty_ratio is none) or (linux.vm.config.dirty_ratio | trim == ''))
+      value: "{{ dn_dirty_ratio }}"
+    when: dn_dirty_ratio is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring percentage of available memory that contains free and reclaimable pages
+  - set_fact:
+      dn_background_ratio: "{{ vm.config.dirty_background_ratio }}"
+    when: vm.config.dirty_background_ratio
+  
+  - set_fact:
+      dn_background_ratio: "{{ linux.vm.config.dirty_background_ratio }}"
+    when:
+      - dn_background_ratio is undefined
+      - linux.vm.config.dirty_background_ratio
+      
+  - name: KAFKA OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring percentage of available memory that contains free and reclaimable pages
     sysctl:
       sysctl_file: "{{ linux.vm.config_file }}"
       name: vm.dirty_background_ratio
-      value: "{{ vm.config.dirty_background_ratio | default(linux.vm.config.dirty_background_ratio) }}"
-    when: not((vm.config.dirty_background_ratio is undefined) or (vm.config.dirty_background_ratio is none) or (vm.config.dirty_background_ratio | trim == '')) or not((linux.vm.config.dirty_background_ratio is undefined) or (linux.vm.config.dirty_background_ratio is none) or (linux.vm.config.dirty_background_ratio | trim == ''))
+      value: "{{ dn_background_ratio }}"
+    when: dn_background_ratio is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring how often the pdflush/flush/kdmflush processes wake up 
+  - set_fact:
+      dn_dirty_writeback: "{{ vm.config.dirty_writeback_centisecs }}"
+    when: vm.config.dirty_writeback_centisecs
+  
+  - set_fact:
+      dn_dirty_writeback: "{{ linux.vm.config.dirty_writeback_centisecs }}"
+    when:
+      - dn_dirty_writeback is undefined
+      - linux.vm.config.dirty_writeback_centisecs
+      
+  - name: KAFKA OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring how often the pdflush/flush/kdmflush processes wake up 
     sysctl:
       sysctl_file: "{{ linux.vm.config_file }}"
       name: vm.dirty_writeback_centisecs
-      value: "{{ vm.config.dirty_writeback_centisecs | default(linux.vm.config.dirty_writeback_centisecs) }}"
-    when: not((vm.config.dirty_writeback_centisecs is undefined) or (vm.config.dirty_writeback_centisecs is none) or (vm.config.dirty_writeback_centisecs | trim == '')) or not((linux.vm.config.dirty_writeback_centisecs is undefined) or (linux.vm.config.dirty_writeback_centisecs is none) or (linux.vm.config.dirty_writeback_centisecs | trim == ''))
+      value: "{{ dn_dirty_writeback }}"
+    when: dn_dirty_writeback is defined
   
-  - name: CONFLUENT OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring how long something can be in cache before it needs to be written
+  - set_fact:
+      dn_dirty_expire: "{{ vm.config.dirty_expire_centisecs }}"
+    when: vm.config.dirty_expire_centisecs
+  
+  - set_fact:
+      dn_dirty_expire: "{{ linux.vm.config.dirty_expire_centisecs }}"
+    when:
+      - dn_dirty_expire is undefined
+      - linux.vm.config.dirty_expire_centisecs
+      
+  - name: KAFKA OVERLAY (PREFLIGHT VIRTUAL MEMORY) | configuring how long something can be in cache before it needs to be written
     sysctl:
       sysctl_file: "{{ linux.vm.config_file }}"
       name: vm.dirty_expire_centisecs
-      value: "{{ vm.config.dirty_expire_centisecs | default(linux.vm.config.dirty_expire_centisecs) }}"
-    when: not((vm.config.dirty_expire_centisecs is undefined) or (vm.config.dirty_expire_centisecs is none) or (vm.config.dirty_expire_centisecs | trim == '')) or not((linux.vm.config.dirty_expire_centisecs is undefined) or (linux.vm.config.dirty_expire_centisecs is none) or (linux.vm.config.dirty_expire_centisecs | trim == ''))
-    
+      value: "{{ dn_dirty_expire }}"
+    when: dn_dirty_expire is defined
+      
   become: yes
   when:
     - ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'

--- a/roles/zookeeper/tasks/interface-facts.yml
+++ b/roles/zookeeper/tasks/interface-facts.yml
@@ -1,11 +1,30 @@
 # (c) Copyright 2016 DataNexus Inc.  All Rights Reserved.
 #
 # automatically set facts based on interfaces present
----    
-- name: setting eth0 to all interfaces
+---
+# this should handle eth or ens prefix with a single or dual interface machine -- is this clever or dangerous
+- set_fact:
+    # set private and public to the same interface by default
+    private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias }}"
+    public_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias }}"
+  when:
+    - hostvars[inventory_hostname].ansible_default_ipv4 is defined
+
+# this is purely to handle single interface machines; define a new possible nic
+- set_fact:
+    possible_private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[:3] }}{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[-1] | int - 1 }}"
+
+# if the possible nic exists then we adopt it   
+- set_fact:
+    # dual NIC machines have default to public internal
+    private_internal_interface: "{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[:3] }}{{ hostvars[inventory_hostname].ansible_default_ipv4.alias[-1] | int - 1 }}"
+  when:
+    - hostvars[inventory_hostname]['ansible_' + possible_private_internal_interface]['ipv4']['address'] is defined
+
+- name: KAFKA OVERLAY (ZOOKEEPER) | setting {{ private_internal_interface }} to all interfaces
   set_fact:
-    zookeeper_interface: "{{ hostvars[inventory_hostname].ansible_eth0.device }}"
-    zookeeper_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}"
-    zookeeper_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.broadcast }}"
-    zookeeper_metrics_interface_ipv4: "{{ hostvars[inventory_hostname].ansible_eth0.ipv4.address }}"
-  when: hostvars[inventory_hostname].ansible_eth0 is defined
+    zookeeper_interface: "{{ hostvars[inventory_hostname]['ansible_' + private_internal_interface]['device'] }}"
+    zookeeper_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + private_internal_interface]['ipv4']['address'] }}"
+    zookeeper_broadcast_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + private_internal_interface]['ipv4']['broadcast'] }}"
+    zookeeper_metrics_interface_ipv4: "{{ hostvars[inventory_hostname]['ansible_' + private_internal_interface]['ipv4']['address'] }}"
+  when: hostvars[inventory_hostname]['ansible_' + private_internal_interface]['ipv4']['address'] is defined


### PR DESCRIPTION
* update interface discovery to support single or multiple interfaes
* add support for application specific preflight (brokers, controlcenter)
* fix tuning variables so they actually work: if tenant or platform defined, if neither defined, if both defined
* various documentation fixes
* fix control center configuration so it works if KSQL and/or registry is not deployed