### PR TITLE
don't build zookeeper off ansible hosts

### DIFF
--- a/provision-kafka
+++ b/provision-kafka
@@ -137,6 +137,13 @@
     - "{{ tenant_config_path }}/config/applications/apache.yml"
   gather_facts: yes
   tasks:
+    # we always build the zookeeper nodes off the admin plane internal IP
+    - name: KAFKA OVERLAY (ZOOKEEPER) | building eth0 zookeeper host group
+      add_host: hostname="{{ hostvars[item].ansible_eth0.ipv4.address }}" groupname=zookeeper_private
+      with_items: "{{ groups['zookeeper'] }}"
+      when:
+        - "'zookeeper' in groups | default([])"
+
     - import_role:
         name: zookeeper
       

--- a/roles/controlcenter/tasks/main.yml
+++ b/roles/controlcenter/tasks/main.yml
@@ -25,7 +25,7 @@
     lineinfile:
       path: "{{ control.center.config_file }}"
       regexp: '^zookeeper.connect='
-      line: "zookeeper.connect={{ groups['zookeeper'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
+      line: "zookeeper.connect={{ groups['zookeeper_private'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
       insertafter: '^#zookeeper.connect='
     notify: restart controlcenter
       

--- a/roles/cruisecontrol/tasks/main.yml
+++ b/roles/cruisecontrol/tasks/main.yml
@@ -172,7 +172,7 @@
       lineinfile:
         path: "{{ cruisecontrol.config_file }}"
         regexp: '^zookeeper.connect='
-        line: "zookeeper.connect={{ groups['zookeeper'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
+        line: "zookeeper.connect={{ groups['zookeeper_private'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
       notify: restart cruisecontrol
       become_user: "{{ cruisecontrol_user }}"
     

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -210,7 +210,7 @@
     lineinfile:
       path: "{{ broker_config_file }}"
       regexp: '^zookeeper.connect='
-      line: "zookeeper.connect={{ groups['zookeeper'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
+      line: "zookeeper.connect={{ groups['zookeeper_private'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
     notify: restart broker
       
   - name: KAFKA OVERLAY (BROKER) | configuring {{ broker_service_name }} zookeeper connection timeout

--- a/roles/kafkarest/tasks/main.yml
+++ b/roles/kafkarest/tasks/main.yml
@@ -34,7 +34,7 @@
     lineinfile:
       path: "{{ kafkarest.config_file }}"
       regexp: '^zookeeper.connect='
-      line: "zookeeper.connect={{ groups['zookeeper'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
+      line: "zookeeper.connect={{ groups['zookeeper_private'] | join(':' + zookeeper.config.port + ',') }}:{{ zookeeper.config.port }}"
       insertafter: '^#zookeeper.connect='
     notify: restart kafkarest
   

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -6,7 +6,7 @@
 # these really need to be the first tasks
 - import_tasks: tune.yml
 - import_tasks: interface-facts.yml
-  
+
 - set_fact: 
     zookeeper_user: "{{ (apache_kafka) | ternary(zookeeper.apache.user, zookeeper.confluent.user) }}"
 
@@ -84,7 +84,7 @@
       line: "syncLimit={{ zookeeper.config.syncLimit }}"
     when: not((zookeeper.config.syncLimit is undefined) or (zookeeper.config.syncLimit is none) or (zookeeper.config.syncLimit | trim == ''))
     notify: restart zookeeper
-    
+
   - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} autopurge.snapRetainCount
     lineinfile:
       path: "{{ zookeeper_config_file }}"
@@ -92,7 +92,7 @@
       line: "autopurge.snapRetainCount={{ zookeeper.config.autopurge_snapRetainCount }}"
     when: not((zookeeper.config.autopurge_snapRetainCount is undefined) or (zookeeper.config.autopurge_snapRetainCount is none) or (zookeeper.config.autopurge_snapRetainCount | trim == ''))
     notify: restart zookeeper
-  
+
   - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} autopurge.purgeInterval
     lineinfile:
       path: "{{ zookeeper_config_file }}"
@@ -101,12 +101,12 @@
     when: not((zookeeper.config.autopurge_purgeInterval is undefined) or (zookeeper.config.autopurge_purgeInterval is none) or (zookeeper.config.autopurge_purgeInterval | trim == ''))
     notify: restart zookeeper
 
-  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ ansible_play_hosts | length }} {{ zookeeper_service_name }} hosts
+  - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ groups['zookeeper_private'] | length }} {{ zookeeper_service_name }} hosts
     lineinfile:
       path: "{{ zookeeper_config_file }}"
       regexp: "^server.{{ item.0 + 1 | int }}="
       line: "server.{{ item.0 + 1 | int }}={{ item.1 }}:2888:3888"
-    with_indexed_items: "{{ ansible_play_hosts }}"
+    with_indexed_items: "{{ groups['zookeeper_private'] }}"
     notify: restart zookeeper
 
   - name: KAFKA OVERLAY (ZOOKEEPER) | configuring {{ zookeeper_service_name }} myid file


### PR DESCRIPTION
We were using the zookeeper ansible host group to configure the platform. That worked fine until we removed the jumphost. Without a jumphost, the ansible hosts are publicly reachable IPs (by design), this means that we must determine the platform IPs dynamically as we touch them. This is now fixed for zookeeper.